### PR TITLE
Make type hints cache thread-safe

### DIFF
--- a/typeguard.py
+++ b/typeguard.py
@@ -45,7 +45,7 @@ class _CallMemo:
         self.type_hints = _type_hints_map.get(func)
         if self.type_hints is None:
             hints = get_type_hints(func)
-            self.type_hints = _type_hints_map[func] = OrderedDict()
+            self.type_hints = OrderedDict()
             for name, parameter in self.signature.parameters.items():
                 if name in hints:
                     annotated_type = hints[name]
@@ -63,6 +63,8 @@ class _CallMemo:
 
             if 'return' in hints:
                 self.type_hints['return'] = hints['return']
+
+            _type_hints_map[func] = self.type_hints
 
 
 def get_type_name(type_):


### PR DESCRIPTION
When the same function is type-checked in multiple threads, a race
condition exists between the full initialization of that function's type
hints in one or more threads and iterating over those hints in one or
more other threads.

This can result in `RuntimeError: OrderedDict mutated during iteration`
in functions that iterate `_CallMemo.type_hints` items.

This fix is to only add the fully initialized type hints dict to the
global type hints cache rather than put an empty dict in the cache and
then subsequently populate that dict.