### PR TITLE
Speed up getting caller's frame

### DIFF
--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -472,7 +472,7 @@ def check_argument_types(memo: Optional[_CallMemo] = None) -> bool:
         try:
             # much faster than inspect, but not officially
             # supported in all python implementations
-            frame = sys._getframe(0).f_back
+            frame = sys._getframe(1)
         except Exception:
             # fall back to slower, but safer method
             frame = inspect.currentframe().f_back

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -469,7 +469,14 @@ def check_argument_types(memo: Optional[_CallMemo] = None) -> bool:
 
     """
     if memo is None:
-        frame = inspect.currentframe().f_back
+        try:
+            # much faster than inspect, but not officially
+            # supported in all python implementations
+            frame = sys._getframe(0).f_back
+        except Exception:
+            # fall back to slower, but safer method
+            frame = inspect.currentframe().f_back
+
         try:
             func = find_function(frame)
         except LookupError:

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -469,13 +469,9 @@ def check_argument_types(memo: Optional[_CallMemo] = None) -> bool:
 
     """
     if memo is None:
-        try:
-            # much faster than inspect, but not officially
-            # supported in all python implementations
-            frame = sys._getframe(1)
-        except Exception:
-            # fall back to slower, but safer method
-            frame = inspect.currentframe().f_back
+        # faster than inspect.currentframe(), but not officially
+        # supported in all python implementations
+        frame = sys._getframe(1)
 
         try:
             func = find_function(frame)


### PR DESCRIPTION
While not officially supported, `sys._getframe()` is waaay faster than `inspect.currentframe()` (on the order of 5x faster).

For benchmarks, see: https://gist.github.com/JettJones/c236494013f22723c1822126df944b12#gistcomment-2962311

This PR attempts to use the `sys._getframe()` if available, and falls back to the slower `inspect` method if not.
Because I don't know of any python implementation that doesn't support `sys._getframe()`, I don't actually know what `Exception` type would be thrown in case of it being unsupported, so for now I just used `Exception`.

(Note: `sys._getframe(1)` is the same as `sys._getframe(0).f_back`)