### PR TITLE
Add support to TypeChecker for callables where __module__ is None

### DIFF
--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -852,10 +852,18 @@ class TestTypeChecker:
         def foo(a: int):
             pass
 
+        def bar(a: int):
+            pass
+
+        bar.__module__ = None
+
         with checker, pytest.warns(TypeWarning) as record:
             assert checker.active
             foo(1)
             foo('x')
+
+            # ignored, __module__ is None
+            bar('z')
 
         assert not checker.active
         foo('x')


### PR DESCRIPTION
Was bitten by type errors when trying to use TypeChecker in a complex environment;
it should check that __module__ is not None before calling .startswith().