### PR TITLE
[TypeChecker] suppress false positive in the exception case

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ There are three principal ways to use type checking, each with its pros and cons
    * noninvasive (only records type violations; does not raise exceptions)
    * does not work reliably with dynamically defined type hints (e.g. in nested functions)
    * may cause problems with badly behaving debuggers or profilers
+   * can not distinguish returning None from raising an exception (i.e. detects slightly less)
 
 If a function is called with incompatible argument types or a ``@typechecked`` decorated function
 returns a value incompatible with the declared type, a descriptive ``TypeError`` exception is

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -700,7 +700,12 @@ class TypeChecker:
                 self._previous_profiler(frame, event, arg)
 
             memo = self._call_memos.pop(frame, None)
-            if memo is not None:
+
+            # Note that the return event is also triggered when exiting a function via an
+            # exception. In this case arg is None and we can not perform any type checking.
+            # Unfortunately, this event is not distinguishable from regularly returning None from a
+            # function. Surpressing the false positive therefore also hides real warnings.
+            if arg is not None and memo is not None:
                 try:
                     check_return_type(arg, memo)
                 except TypeError as exc:


### PR DESCRIPTION
Unfortunately, exceptions and regular returns of None seem to be
indistinguishable via the profiler interface. As the result,
this change also hides real warnings.

For now I only documented this limitation. However, better ideas to deal with this issue are more than welcome.

fixes #68