### PR TITLE
Fixed yielded Iterable return types to not error

### DIFF
--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -903,6 +903,18 @@ class TestTypeChecked:
 
         assert exc.value.value == ['2', '3', '4']
 
+    def test_iterable_yield(self):
+        @typechecked
+        def genfunc() -> Iterable[int]:
+            for val in [2, 3, 4]:
+                yield val
+
+        gen = genfunc()
+        with pytest.raises(StopIteration):
+            while True:
+                value = next(gen)
+                assert isinstance(value, int)
+
     def test_generator_bad_yield(self):
         @typechecked
         def genfunc() -> Generator[int, str, None]:

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -595,8 +595,13 @@ class TypeCheckedGenerator:
     def __init__(self, wrapped: Generator, memo: _CallMemo):
         self.__wrapped = wrapped
         self.__memo = memo
-        self.__yield_type, self.__send_type, self.__return_type = \
-            memo.type_hints['return'].__args__
+        try:
+            self.__yield_type, self.__send_type, self.__return_type = \
+                memo.type_hints['return'].__args__
+        except ValueError:
+            # Handle Iterable case where only the yield type is available
+            self.__yield_type = memo.type_hints['return'].__args__[0]
+            self.__send_type, self.__return_type = None, None
         self.__initialized = False
 
     def __iter__(self):


### PR DESCRIPTION
The latest 2.5.0 release caused

```
    @typechecked
    def yielding_func(self) -> Iterable[str]:
      yield 'foo'
```

to start failing with

```
typeguard/__init__.py:706: in wrapper
    return TypeCheckedGenerator(retval, memo)
typeguard/__init__.py:599: in __init__
    memo.type_hints['return'].__args__
E   ValueError: not enough values to unpack (expected 3, got 1)
```

Adding a catch for the return hints being a length 1 tuple for Iterator class yields (as opposed to 3 length Generator tuples) fixed the issue.