### PR TITLE
Fix crash when warning about annotated functions if function is object or partial function.

### DIFF
--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1022,6 +1022,24 @@ class TestTypeChecked:
         assert Child.foo('bar') == 'Child'
         pytest.raises(TypeError, Child.foo, 1)
 
+    def test_decorator_factory_no_annotations(self):
+        class CallableClass:
+            def __call__(self):
+                pass
+
+        def decorator_factory():
+            def decorator(f):
+                cmd = CallableClass()
+                return cmd
+
+            return decorator
+
+        with pytest.warns(UserWarning):
+            @typechecked
+            @decorator_factory()
+            def foo():
+                pass
+
 
 class TestTypeChecker:
     @pytest.fixture

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -193,7 +193,7 @@ def qualified_name(obj) -> str:
     return qualname if module in ('typing', 'builtins') else '{}.{}'.format(module, qualname)
 
 
-def function_name(func: FunctionType) -> str:
+def function_name(func: Callable) -> str:
     """
     Return the qualified name of the given function.
 
@@ -202,7 +202,8 @@ def function_name(func: FunctionType) -> str:
 
     """
     module = func.__module__
-    qualname = func.__qualname__
+    # For partial functions and objects with __call__ defined, __qualname__ does not exist
+    qualname = getattr(func, '__qualname__', repr(func))
     return qualname if module == 'builtins' else '{}.{}'.format(module, qualname)
 
 

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -201,8 +201,8 @@ def function_name(func: Callable) -> str:
     name stripped from the generated name.
 
     """
-    module = func.__module__
     # For partial functions and objects with __call__ defined, __qualname__ does not exist
+    module = func.__module__
     qualname = getattr(func, '__qualname__', repr(func))
     return qualname if module == 'builtins' else '{}.{}'.format(module, qualname)
 


### PR DESCRIPTION
- function_name() is called when we warn about unannotated functions in the @typechecked decorator.
- Inside the typechecked decorator, `func` can be any callable, not just functions
- `function_name` was relying on being called only with functions, but was actually therefore potentially being called with any unannotated callable
- Two instances of situations where `__qualname__` is not available for callables: partially-applied functions + objects with `__call__` methods.