### PR TITLE
Add support for Mock and MagicMock types.

### DIFF
--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -4,6 +4,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps, partial, lru_cache
 from io import StringIO, BytesIO
+from unittest.mock import MagicMock
 from typing import (
     Any, Callable, Dict, List, Set, Tuple, Union, TypeVar, Sequence, NamedTuple, Iterable,
     Container, Generic, BinaryIO, TextIO, Generator, Iterator, SupportsInt, AbstractSet)
@@ -82,6 +83,12 @@ class TestCheckArgumentTypes:
             assert check_argument_types()
 
         foo('aa')
+
+    def test_magicmock_value(self):
+        def foo(a: str, b: int, c: dict, d: Any) -> int:
+            assert check_argument_types()
+
+        foo(MagicMock(), MagicMock(), MagicMock(), MagicMock())
 
     def test_callable_exact_arg_count(self):
         def foo(a: Callable[[int, str], int]):
@@ -721,6 +728,13 @@ class TestTypeChecked:
 
         exc = pytest.raises(TypeError, foo)
         assert str(exc.value) == 'type of the return value must be NoneType; got str instead'
+
+    def test_return_type_magicmock(self):
+        @typechecked
+        def foo() -> str:
+            return MagicMock()
+
+        foo()
 
     @pytest.mark.parametrize('typehint', [
         Callable[..., int],

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -38,9 +38,9 @@ class Child(Parent):
     def method(self, a: int):
         pass
 
-    
+
 @pytest.fixture(params=[Mock, MagicMock], ids=['mock', 'magicmock'])
-def mock_class(request)
+def mock_class(request):
     return request.param
 
 

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -4,7 +4,7 @@ import warnings
 from concurrent.futures import ThreadPoolExecutor
 from functools import wraps, partial, lru_cache
 from io import StringIO, BytesIO
-from unittest.mock import MagicMock
+from unittest.mock import Mock, MagicMock
 from typing import (
     Any, Callable, Dict, List, Set, Tuple, Union, TypeVar, Sequence, NamedTuple, Iterable,
     Container, Generic, BinaryIO, TextIO, Generator, Iterator, SupportsInt, AbstractSet)
@@ -37,6 +37,11 @@ class Parent:
 class Child(Parent):
     def method(self, a: int):
         pass
+
+    
+@pytest.fixture(params=[Mock, MagicMock], ids=['mock', 'magicmock'])
+def mock_class(request)
+    return request.param
 
 
 @pytest.mark.parametrize('inputval, expected', [
@@ -84,11 +89,11 @@ class TestCheckArgumentTypes:
 
         foo('aa')
 
-    def test_magicmock_value(self):
+    def test_mock_value(self, mock_class):
         def foo(a: str, b: int, c: dict, d: Any) -> int:
             assert check_argument_types()
 
-        foo(MagicMock(), MagicMock(), MagicMock(), MagicMock())
+        foo(mock_class(), mock_class(), mock_class(), mock_class())
 
     def test_callable_exact_arg_count(self):
         def foo(a: Callable[[int, str], int]):
@@ -729,10 +734,10 @@ class TestTypeChecked:
         exc = pytest.raises(TypeError, foo)
         assert str(exc.value) == 'type of the return value must be NoneType; got str instead'
 
-    def test_return_type_magicmock(self):
+    def test_return_type_magicmock(self, mock_class):
         @typechecked
         def foo() -> str:
-            return MagicMock()
+            return mock_class()
 
         foo()
 

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -17,6 +17,7 @@ from typing import (
     Callable, Any, Union, Dict, List, TypeVar, Tuple, Set, Sequence, get_type_hints, TextIO,
     Optional, IO, BinaryIO, Type, Generator, overload, Iterable, AsyncIterable, Iterator,
     AsyncIterator, AbstractSet)
+from unittest.mock import Mock
 from warnings import warn
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
@@ -552,7 +553,7 @@ def check_type(argname: str, value, expected_type, memo: Optional[_CallMemo] = N
     :param expected_type: a class or generic type instance
 
     """
-    if expected_type is Any:
+    if expected_type is Any or isinstance(value, Mock):
         return
 
     if expected_type is None:


### PR DESCRIPTION
These are analogous to Any, except for values instead of arguments.

Any accepts any value. MagicMock can pretend to be any type.