### PR TITLE
Support backport Literal from typing_extensions

### DIFF
--- a/tests/test_typeguard_py36.py
+++ b/tests/test_typeguard_py36.py
@@ -4,6 +4,7 @@ from typing import AsyncGenerator, AsyncIterable, AsyncIterator
 import pytest
 
 from typeguard import TypeChecker, typechecked
+from typing_extensions import Literal
 
 
 class TestTypeChecked:
@@ -106,3 +107,12 @@ class TestTypeChecker:
             func()
 
         assert len(record) == 0
+
+
+def test_literal():
+    @typechecked
+    def foo(a: Literal[1, 6, 8]):
+        pass
+
+    foo(6)
+    pytest.raises(TypeError, foo, 4).match(r'must be one of \(1, 6, 8\); got 4 instead$')

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -29,7 +29,7 @@ except ImportError:
 try:
     from typing_extensions import Literal as BPLiteral
 except ImportError:
-    pass
+    BPLiteral = None
 
 try:
     from typing import AsyncGenerator

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -27,6 +27,11 @@ except ImportError:
     Literal = TypedDict = None
 
 try:
+    from typing_extensions import Literal as BPLiteral
+except ModuleNotFoundError:
+    pass
+
+try:
     from typing import AsyncGenerator
 except ImportError:
     AsyncGenerator = None
@@ -465,9 +470,15 @@ def check_typevar(argname: str, value, typevar: TypeVar, memo: Optional[_CallMem
 
 
 def check_literal(argname: str, value, expected_type, memo: Optional[_CallMemo]):
-    if value not in expected_type.__args__:
+    try:
+        args = expected_type.__args__
+    except AttributeError:
+        # Instance of Literal from typing_extensions.
+        args = expected_type.__values__
+
+    if value not in args:
         raise TypeError('the value of {} must be one of {}; got {} instead'.
-                        format(argname, expected_type.__args__, value))
+                        format(argname, args, value))
 
 
 def check_number(argname: str, value, expected_type):
@@ -523,6 +534,8 @@ if Type is not None:
     origin_type_checkers[Type] = check_class
 if Literal is not None:
     origin_type_checkers[Literal] = check_literal
+if BPLiteral is not None:
+    origin_type_checkers[BPLiteral] = check_literal
 
 generator_origin_types = (Generator, collections.abc.Generator,
                           Iterator, collections.abc.Iterator,
@@ -595,6 +608,9 @@ def check_type(argname: str, value, expected_type, memo: Optional[_CallMemo] = N
     elif isinstance(expected_type, TypeVar):
         # Only happens on < 3.6
         check_typevar(argname, value, expected_type, memo)
+    elif BPLiteral is not None and isinstance(expected_type, BPLiteral.__class__):
+        # Only happens on < 3.7 when using Literal from typing_extensions
+        check_literal(argname, value, expected_type, memo)
     elif (isfunction(expected_type) and
             getattr(expected_type, "__module__", None) == "typing" and
             getattr(expected_type, "__qualname__", None).startswith("NewType.") and

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -28,7 +28,7 @@ except ImportError:
 
 try:
     from typing_extensions import Literal as BPLiteral
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 try:
@@ -473,7 +473,7 @@ def check_literal(argname: str, value, expected_type, memo: Optional[_CallMemo])
     try:
         args = expected_type.__args__
     except AttributeError:
-        # Instance of Literal from typing_extensions.
+        # Instance of Literal from typing_extensions
         args = expected_type.__values__
 
     if value not in args:


### PR DESCRIPTION
Allows the type checker to support `Literal` types in python `3.5` through `3.7` if `typing_extensions` is installed.

For example: I'm writing a program targeted to python 3.8 but must maintain support for 3.7. The official [typing_extensions](https://github.com/python/typing/tree/master/typing_extensions) package backports `Literal`. However, despite this type now being available in my 3.7 runtime, typeguard's type checking fails to raise TypeError on invalid values.

Unfortunately, it's a little complicated. In `3.5 <= py < 3.7`, the `Literal` type does not have either `__origin__` nor `__args__`, so this is special cased in `check_type`