### PR TITLE
Don't try to wrap generators that are untyped.

### DIFF
--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -561,6 +561,17 @@ class TestCheckArgumentTypes:
         gen = generate(1)
         next(gen)
 
+    def test_wrapped_generator_no_return_type_annotation(self):
+        """Test that return type checking works in a generator function too."""
+        @typechecked
+        def generate(a: int):
+            yield a
+            yield a + 1
+
+        gen = generate(1)
+        next(gen)
+
+
     def test_varargs(self):
         def foo(*args: int):
             assert check_argument_types()

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -571,7 +571,6 @@ class TestCheckArgumentTypes:
         gen = generate(1)
         next(gen)
 
-
     def test_varargs(self):
         def foo(*args: int):
             assert check_argument_types()

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -814,7 +814,7 @@ def typechecked(func=None, *, always=False, _localns: Optional[Dict[str, Any]] =
         if inspect.isgenerator(retval) or isasyncgen(retval):
             return_type = memo.type_hints.get('return')
             if return_type:
-                origin = getattr(return_type, '__origin__')
+                origin = getattr(return_type, '__origin__', None)
                 if origin in generator_origin_types:
                     return TypeCheckedGenerator(retval, memo)
                 elif origin is not None and origin in asyncgen_origin_types:

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -813,11 +813,12 @@ def typechecked(func=None, *, always=False, _localns: Optional[Dict[str, Any]] =
         # If a generator is returned, wrap it if its yield/send/return types can be checked
         if inspect.isgenerator(retval) or isasyncgen(retval):
             return_type = memo.type_hints.get('return')
-            origin = getattr(return_type, '__origin__')
-            if origin in generator_origin_types:
-                return TypeCheckedGenerator(retval, memo)
-            elif origin is not None and origin in asyncgen_origin_types:
-                return TypeCheckedAsyncGenerator(retval, memo)
+            if return_type:
+                origin = getattr(return_type, '__origin__')
+                if origin in generator_origin_types:
+                    return TypeCheckedGenerator(retval, memo)
+                elif origin is not None and origin in asyncgen_origin_types:
+                    return TypeCheckedAsyncGenerator(retval, memo)
 
         return retval
 


### PR DESCRIPTION
Generators that do not have return type signatures set would cause a crash within typeguard. This fixes that.