### PR TITLE
Compare types of module attributes with their annotations after module import

### DIFF
--- a/tests/dummymodule_3_6.py
+++ b/tests/dummymodule_3_6.py
@@ -1,0 +1,13 @@
+
+# module for syntax that does not supported in Python 3.5
+
+import os
+
+
+annotated_attribute: int = 100500
+
+not_annotated_attribute = 100600
+
+
+if 'TYPEGUARD_TEST_WRONG_ANNOTATION' in os.environ:
+    wrong_annotated_attribute: int = 1.5


### PR DESCRIPTION
Hi!

What are you thinking about checking types of module-level attributes after module imported?

It will help to find errors like:

```
x: int = 1
y: int = x / 2 # type error here 
```

And it matches the approach of run-time type checking.