### PR TITLE
Fix flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,5 @@ commands = python -m pytest {posargs}
 
 [testenv:flake8]
 deps = flake8
-commands = flake8 typeguard.py tests
+commands = flake8 typeguard tests
 skip_install = true

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -27,11 +27,6 @@ except ImportError:
     Literal = TypedDict = None
 
 try:
-    from typing import Protocol
-except ImportError:
-    from typing import _Protocol as Protocol
-
-try:
     from typing import AsyncGenerator
 except ImportError:
     AsyncGenerator = None


### PR DESCRIPTION
Flake8 is currently broken, resulting in failed master CI builds and blocking all merge requests. Some merge requests aren't blocked, but that's because their CI hasn't run recently. Fixes #126 