### PR TITLE
Prevent all SpecialForms from using check_literal

### DIFF
--- a/tests/test_typeguard_py38.py
+++ b/tests/test_typeguard_py38.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypedDict, Union
+from typing import Literal, NoReturn, TypedDict, Union
 
 import pytest
 
@@ -22,6 +22,14 @@ def test_literal_union():
     foo(6)
     pytest.raises(TypeError, foo, 4).\
         match(r'must be one of \(str, typing.Literal\[1, 6, 8\]\); got int instead$')
+
+
+def test_regression_131():
+    @typechecked
+    def foo() -> NoReturn:
+        pass
+
+    foo()
 
 
 @pytest.mark.parametrize('value, total, error_re', [

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -608,7 +608,8 @@ def check_type(argname: str, value, expected_type, memo: Optional[_CallMemo] = N
     elif isinstance(expected_type, TypeVar):
         # Only happens on < 3.6
         check_typevar(argname, value, expected_type, memo)
-    elif BPLiteral is not None and isinstance(expected_type, BPLiteral.__class__):
+    elif BPLiteral is not None and Literal is None \
+            and isinstance(expected_type, BPLiteral.__class__):
         # Only happens on < 3.7 when using Literal from typing_extensions
         check_literal(argname, value, expected_type, memo)
     elif (isfunction(expected_type) and


### PR DESCRIPTION
Fixes #131 

@agronholm Sorry to introduce a bug like this. Wasn't caught by the existing test suites and I didn't catch it until testing my project with typeguard==2.8.0. I've added a regression test. Would appreciate a patch release :)