### PR TITLE
make typeguard work on python3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,11 @@ jobs:
       python: "3.8"
       after_success: *after_success
 
+    - stage: test
+      env: TOXENV=py39
+      python: "3.9-dev"
+      after_success: *after_success
+
     - stage: deploy to pypi
       install: skip
       script: skip

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -10,7 +10,17 @@ from typing import (
     Container, Generic, BinaryIO, TextIO, Generator, Iterator, AbstractSet, AnyStr, Type)
 
 import pytest
-from typing_extensions import NoReturn, Protocol, Literal, TypedDict, runtime_checkable
+try:
+    from typing_extensions import NoReturn, Protocol, Literal, TypedDict, runtime_checkable
+except ImportError:
+    try:
+        from typing import NoReturn, Protocol, Literal, TypedDict, runtime_checkable
+    except ImportError:
+        NoReturn = None
+        Protocol = None
+        Literal = None
+        TypedDict = None
+        runtime_checkable = None
 
 from typeguard import (
     typechecked, check_argument_types, qualified_name, TypeChecker, TypeWarning, function_name,

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -12,7 +12,6 @@ from typing import (
 import pytest
 from typing_extensions import NoReturn, Protocol, Literal, TypedDict, runtime_checkable
 
-
 from typeguard import (
     typechecked, check_argument_types, qualified_name, TypeChecker, TypeWarning, function_name,
     check_type, TypeHintWarning, ForwardRefPolicy, check_return_type)

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -10,17 +10,8 @@ from typing import (
     Container, Generic, BinaryIO, TextIO, Generator, Iterator, AbstractSet, AnyStr, Type)
 
 import pytest
-try:
-    from typing_extensions import NoReturn, Protocol, Literal, TypedDict, runtime_checkable
-except ImportError:
-    try:
-        from typing import NoReturn, Protocol, Literal, TypedDict, runtime_checkable
-    except ImportError:
-        NoReturn = None
-        Protocol = None
-        Literal = None
-        TypedDict = None
-        runtime_checkable = None
+from typing_extensions import NoReturn, Protocol, Literal, TypedDict, runtime_checkable
+
 
 from typeguard import (
     typechecked, check_argument_types, qualified_name, TypeChecker, TypeWarning, function_name,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = pypy3, py35, py36, py37, py38, flake8
+envlist = pypy3, py35, py36, py37, py38, py39, flake8
 skip_missing_interpreters = true
 isolated_build = true
 

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -752,6 +752,7 @@ class TypeCheckedGenerator:
         rtype_args = []
         if hasattr(memo.type_hints['return'], "__args__"):
             rtype_args = memo.type_hints['return'].__args__
+
         self.__wrapped = wrapped
         self.__memo = memo
         self.__yield_type = rtype_args[0] if rtype_args else Any


### PR DESCRIPTION
Add python 3.9 to tox.ini
make tests pass for 3.9 as well as other supported python versions
fix #149 