### PR TITLE
Fix #155

### DIFF
--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -65,7 +65,7 @@ _type_hints_map = WeakKeyDictionary()  # type: Dict[FunctionType, Dict[str, Any]
 _functions_map = WeakValueDictionary()  # type: Dict[CodeType, FunctionType]
 _missing = object()
 
-T_CallableOrType = TypeVar('T_CallableOrType', Callable, Type[Any])
+T_CallableOrType = TypeVar('T_CallableOrType', bound=Callable[..., Any])
 
 
 class ForwardRefPolicy(Enum):


### PR DESCRIPTION
Maybe I'm not understanding mypy or the typing module entirely, but it seems that TypeVar(name, bound=Callable[....]) is not treated the same as TypeVar(name, Callable[....], OtherType). But Type[T] is considered a subtype of Callable[..., T], at least in Python 3.8, and that subtype hierarchy is all typeguard needs.