### PR TITLE
Typechecked class properties

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -48,7 +48,8 @@ function is to use the ``@typechecked`` decorator::
 
     @typechecked
     class SomeClass:
-        # All type annotated methods (including static and class methods) are type checked.
+        # All type annotated methods (including static and class methods and properties)
+        # are type checked.
         # Does not apply to inner classes!
         def method(x: int) -> int:
             ...

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1172,6 +1172,9 @@ class TestTypeChecked:
         @typechecked
         class Foo:
 
+            def __init__(self) -> None:
+                self.foo = 'foo'
+
             @property
             def prop(self) -> int:
                 """
@@ -1181,19 +1184,21 @@ class TestTypeChecked:
 
             @property
             def prop2(self) -> str:
-                return 'foo'
+                return self.foo
 
             @prop2.setter
             def prop2(self, value: str) -> None:
-                pass
+                self.foo = value
 
-        assert Foo().prop == 4
         assert Foo.__dict__["prop"].__doc__.strip() == "My property."
-        assert Foo().prop2 == 'foo'
-        Foo().prop2 = 'bar'
+        f = Foo()
+        assert f.prop == 4
+        assert f.prop2 == 'foo'
+        f.prop2 = 'bar'
+        assert f.prop2 == 'bar'
 
         with pytest.raises(TypeError) as raises:
-            Foo().prop2 = 3
+            f.prop2 = 3
         assert raises.value.args[0] == 'type of argument "value" must be str; got int instead'
 
     def test_decorator_factory_no_annotations(self):

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -995,10 +995,34 @@ class TestTypeChecked:
             def method(self) -> int:
                 return 'foo'
 
+            @property
+            def prop(self) -> int:
+                return 'foo'
+
+            @property
+            def prop2(self) -> int:
+                return 'foo'
+
+            @prop2.setter
+            def prop2(self, value: int) -> None:
+                pass
+
         pattern = 'type of the return value must be int; got str instead'
         pytest.raises(TypeError, Foo.staticmethod).match(pattern)
         pytest.raises(TypeError, Foo.classmethod).match(pattern)
         pytest.raises(TypeError, Foo().method).match(pattern)
+
+        with pytest.raises(TypeError) as raises:
+            Foo().prop
+        assert raises.value.args[0] == pattern
+
+        with pytest.raises(TypeError) as raises:
+            Foo().prop2
+        assert raises.value.args[0] == pattern
+
+        with pytest.raises(TypeError) as raises:
+            Foo().prop2 = 'foo'
+        assert raises.value.args[0] == 'type of argument "value" must be int; got str instead'
 
     @pytest.mark.parametrize('annotation', [
         Generator[int, str, List[str]],
@@ -1142,6 +1166,35 @@ class TestTypeChecked:
 
         assert Child.foo('bar') == 'Child'
         pytest.raises(TypeError, Child.foo, 1)
+
+    def test_class_property(self):
+
+        @typechecked
+        class Foo:
+
+            @property
+            def prop(self) -> int:
+                """
+                My property.
+                """
+                return 4
+
+            @property
+            def prop2(self) -> str:
+                return 'foo'
+
+            @prop2.setter
+            def prop2(self, value: str) -> None:
+                pass
+
+        assert Foo().prop == 4
+        assert Foo.__dict__["prop"].__doc__.strip() == "My property."
+        assert Foo().prop2 == 'foo'
+        Foo().prop2 = 'bar'
+
+        with pytest.raises(TypeError) as raises:
+            Foo().prop2 = 3
+        assert raises.value.args[0] == 'type of argument "value" must be str; got int instead'
 
     def test_decorator_factory_no_annotations(self):
         class CallableClass:

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1014,14 +1014,17 @@ class TestTypeChecked:
 
         with pytest.raises(TypeError) as raises:
             Foo().prop
+
         assert raises.value.args[0] == pattern
 
         with pytest.raises(TypeError) as raises:
             Foo().prop2
+
         assert raises.value.args[0] == pattern
 
         with pytest.raises(TypeError) as raises:
             Foo().prop2 = 'foo'
+
         assert raises.value.args[0] == 'type of argument "value" must be int; got str instead'
 
     @pytest.mark.parametrize('annotation', [
@@ -1199,6 +1202,7 @@ class TestTypeChecked:
 
         with pytest.raises(TypeError) as raises:
             f.prop2 = 3
+
         assert raises.value.args[0] == 'type of argument "value" must be str; got int instead'
 
     def test_decorator_factory_no_annotations(self):

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1171,18 +1171,14 @@ class TestTypeChecked:
         pytest.raises(TypeError, Child.foo, 1)
 
     def test_class_property(self):
-
         @typechecked
         class Foo:
-
             def __init__(self) -> None:
                 self.foo = 'foo'
 
             @property
             def prop(self) -> int:
-                """
-                My property.
-                """
+                """My property."""
                 return 4
 
             @property

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -882,7 +882,7 @@ def typechecked(func=None, *, always=False, _localns: Optional[Dict[str, Any]] =
                         property_func, always=always, _localns=func.__dict__
                     )
 
-               setattr(func, key, property(**kwargs))
+                setattr(func, key, property(**kwargs))
 
         return func
 

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -848,8 +848,9 @@ def typechecked(func=None, *, always=False, _localns: Optional[Dict[str, Any]] =
     If the ``__debug__`` global variable is set to ``False``, no wrapping and therefore no type
     checking is done, unless ``always`` is ``True``.
 
-    This can also be used as a class decorator. This will wrap all type annotated methods in the
-    class with this decorator.
+    This can also be used as a class decorator. This will wrap all type annotated methods,
+    including ``@classmethod``, ``@staticmethod``,  and ``@property`` decorated methods,
+    in the class with the ``@typechecked`` decorator.
 
     :param func: the function or class to enable type checking for
     :param always: ``True`` to enable type checks even in optimized mode

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -871,6 +871,16 @@ def typechecked(func=None, *, always=False, _localns: Optional[Dict[str, Any]] =
                 if getattr(attr.__func__, '__annotations__', None):
                     wrapped = typechecked(attr.__func__, always=always, _localns=func.__dict__)
                     setattr(func, key, type(attr)(wrapped))
+            elif isinstance(attr, property):
+                kwargs = dict(doc=attr.__doc__)
+                for name in ("fset", "fget", "fdel"):
+                    property_func = getattr(attr, name)
+                    if property_func is None:
+                        continue
+                    kwargs[name] = typechecked(
+                        property_func, always=always, _localns=func.__dict__
+                    )
+                setattr(func, key, property(**kwargs))
 
         return func
 

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -881,7 +881,8 @@ def typechecked(func=None, *, always=False, _localns: Optional[Dict[str, Any]] =
                     kwargs[name] = typechecked(
                         property_func, always=always, _localns=func.__dict__
                     )
-                setattr(func, key, property(**kwargs))
+
+               setattr(func, key, property(**kwargs))
 
         return func
 


### PR DESCRIPTION
Check `@property`s when `@typechecked` decorates a class.