### PR TITLE
Fix docs warning

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -210,7 +210,7 @@ Type            Notes
                 more information); On Python 3.9.0 or ``typing_extensions``
                 <= 3.7.4.3, false positives can happen when constructing
                 ``TypedDict`` classes using old-style syntax (see
-               `issue 42059`_)
+                `issue 42059`_)
 ``TypeVar``     Constraints, bound types and co/contravariance are supported
                 but custom generic types are not (due to type erasure)
 ``Union``

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = pypy3, py35, py36, py37, py38, py39, flake8, docs
+envlist = pypy3, py35, py36, py37, py38, py39, flake8
 skip_missing_interpreters = true
 isolated_build = true
 
@@ -15,12 +15,3 @@ commands =
 deps = flake8
 commands = flake8 typeguard tests
 skip_install = true
-
-[testenv:docs]
-deps =
-  sphinx
-  sphinx-autodoc-typehints
-  sphinx_rtd_theme
-commands = make html
-allowedlist_externals = /usr/bin/make
-changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = pypy3, py35, py36, py37, py38, py39, flake8
+envlist = pypy3, py35, py36, py37, py38, py39, flake8, docs
 skip_missing_interpreters = true
 isolated_build = true
 
@@ -15,3 +15,12 @@ commands =
 deps = flake8
 commands = flake8 typeguard tests
 skip_install = true
+
+[testenv:docs]
+deps =
+  sphinx
+  sphinx-autodoc-typehints
+  sphinx_rtd_theme
+commands = make html
+allowedlist_externals = /usr/bin/make
+changedir = docs


### PR DESCRIPTION
Fixes a doc warning that's causing the table to be missing from here https://typeguard.readthedocs.io/en/latest/userguide.html#supported-typing-types

Also adds a tox env to easily build docs.