### PR TITLE
fix: only check yielded and sent values to generators when annotated by user

### DIFF
--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1069,6 +1069,15 @@ class TestTypeChecked:
 
         exc.match('type of value yielded from generator must be int; got str instead')
 
+    def test_generator_bare_covariant(self):
+        @typechecked
+        def genfunc() -> Generator:
+            yield "42"
+            yield 42
+
+        *values, = genfunc()
+        assert values == ["42", 42]
+
     def test_generator_bad_send(self):
         @typechecked
         def genfunc() -> Generator[int, str, None]:

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -753,8 +753,10 @@ def check_argument_types(memo: Optional[_CallMemo] = None) -> bool:
 class TypeCheckedGenerator:
     def __init__(self, wrapped: Generator, memo: _CallMemo):
         rtype_args = []
-        if hasattr(memo.type_hints['return'], "__args__"):
-            rtype_args = memo.type_hints['return'].__args__
+        rtype = memo.type_hints['return']
+        if (hasattr(rtype, "__args__") and
+                rtype.__args__ not in (None, getattr(rtype, "__parameters__", None))):
+            rtype_args = rtype.__args__
 
         self.__wrapped = wrapped
         self.__memo = memo

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -792,7 +792,13 @@ class TypeCheckedGenerator:
             check_type('return value', exc.value, self.__return_type, memo=self.__memo)
             raise
 
-        check_type('value yielded from generator', value, self.__yield_type, memo=self.__memo)
+        try:
+            check_type('value yielded from generator', value, self.__yield_type, memo=self.__memo)
+        except TypeError as exc:
+            # suppress unnecessarily long tracebacks
+            exc = exc.with_traceback(None)
+            # Raise exception from yield statement that produced the value
+            self.__wrapped.throw(exc)
         return value
 
 


### PR DESCRIPTION
Without this we end up trying to enforce that every value yielded from
an iterator has the same type as those coming before it.

The added test case illustrates this.