### PR TITLE
Add postpone evaluation

### DIFF
--- a/tests/dummymodule.py
+++ b/tests/dummymodule.py
@@ -56,6 +56,9 @@ class DummyClass(metaclass=Metaclass):
         pass
 
 
+dummy_object = DummyClass()
+
+
 def outer():
     class Inner:
         pass

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1180,6 +1180,41 @@ class TestTypeChecked:
         assert foo_union(dummy_object) is None
         assert foo_union('hi') is None
 
+        @typechecked
+        def foo_list(x: List[Union['DummyClass', str]]) -> None:
+            assert check_argument_types()
+            return None
+
+        pytest.raises(TypeError, foo_list, [1])
+        pytest.raises(TypeError, foo_list, [Child()])
+        pytest.raises(TypeError, foo_list, [dummy_object, 1])
+        assert foo_list([]) is None
+        assert foo_list([dummy_object, 'object']) is None
+        assert foo_list([dummy_object, dummy_object]) is None
+
+        @typechecked
+        def foo_dict(x: Dict[str, 'DummyClass']) -> None:
+            assert check_argument_types()
+            return None
+
+        pytest.raises(TypeError, foo_dict, {'1': Child()})
+        pytest.raises(TypeError, foo_dict, {'1': 1})
+        assert foo_dict({'1': dummy_object}) is None
+
+        @typechecked
+        def foo_dict_list(x: Dict[str, List[Union['DummyClass', str]]]) -> None:
+            assert check_argument_types()
+            return None
+
+        pytest.raises(TypeError, foo_dict_list, {'1': dummy_object})
+        pytest.raises(TypeError, foo_dict_list, {'1': '1'})
+        pytest.raises(TypeError, foo_dict_list, {'1': [1]})
+        pytest.raises(TypeError, foo_dict_list, {'1': [dummy_object, 1]})
+        pytest.raises(TypeError, foo_dict_list, {'1': ['1', 1]})
+        assert foo_dict_list({'1': []}) is None
+        assert foo_dict_list({'1': [dummy_object]}) is None
+        assert foo_dict_list({'1': [dummy_object, 'hi']}) is None
+
     def test_inherited_class_method(self):
         @typechecked
         class Parent:


### PR DESCRIPTION
This PR adds ``postpone_evaluation`` parameter to methods. Postponing evaluation is the same as importing ``from __future__ import annotation``. Fixes #168.

Postponing evaluation and checking class inheritance lets typecheck classes imported using ``TYPE_CHECKING``, see new tests:

```python
from typing import TYPE_CHECKING
from dummymodule import dummy_object # dummy_object = DummyClass()

if TYPE_CHECKING:
    from dummymodule import DummyClass

...
def test_string_defined_class(self):
    @typechecked
    def foo(x: 'DummyClass') -> None:
        assert check_argument_types()
        return None

    pytest.raises(TypeError, foo, Child())
    assert foo(dummy_object) is None

    @typechecked
    def foo_union(x: Union['DummyClass', str]) -> None:
        assert check_argument_types()
        return None

    pytest.raises(TypeError, foo_union, Child())
    pytest.raises(TypeError, foo_union, 1)
    assert foo_union(dummy_object) is None
    assert foo_union('hi') is None
```

With ``postpone_evaluation=False`` the test fails on each case, raising `NameError`. I know ``forward_refs_policy`` manages the behaviour of ``NameError``, but the current module architecture don't let to manage this issue.

The biggest problem of this PR is:

1. Ignores the behaviour of ``forward_refs_policy``
2. Rewrites ``typing`` ``_eval_type`` and ``get_type_hints`` methods.

Maybe  ``postpone_evaluation`` can be set to ``False``