### PR TITLE
Add postpone evaluation

### DIFF
--- a/tests/dummymodule.py
+++ b/tests/dummymodule.py
@@ -56,6 +56,9 @@ class DummyClass(metaclass=Metaclass):
         pass
 
 
+dummy_object = DummyClass()
+
+
 def outer():
     class Inner:
         pass

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1180,6 +1180,41 @@ class TestTypeChecked:
         assert foo_union(dummy_object) is None
         assert foo_union('hi') is None
 
+        @typechecked
+        def foo_list(x: List[Union['DummyClass', str]]) -> None:
+            assert check_argument_types()
+            return None
+
+        pytest.raises(TypeError, foo_list, [1])
+        pytest.raises(TypeError, foo_list, [Child()])
+        pytest.raises(TypeError, foo_list, [dummy_object, 1])
+        assert foo_list([]) is None
+        assert foo_list([dummy_object, 'object']) is None
+        assert foo_list([dummy_object, dummy_object]) is None
+
+        @typechecked
+        def foo_dict(x: Dict[str, 'DummyClass']) -> None:
+            assert check_argument_types()
+            return None
+
+        pytest.raises(TypeError, foo_dict, {'1': Child()})
+        pytest.raises(TypeError, foo_dict, {'1': 1})
+        assert foo_dict({'1': dummy_object}) is None
+
+        @typechecked
+        def foo_dict_list(x: Dict[str, List[Union['DummyClass', str]]]) -> None:
+            assert check_argument_types()
+            return None
+
+        pytest.raises(TypeError, foo_dict_list, {'1': dummy_object})
+        pytest.raises(TypeError, foo_dict_list, {'1': '1'})
+        pytest.raises(TypeError, foo_dict_list, {'1': [1]})
+        pytest.raises(TypeError, foo_dict_list, {'1': [dummy_object, 1]})
+        pytest.raises(TypeError, foo_dict_list, {'1': ['1', 1]})
+        assert foo_dict_list({'1': []}) is None
+        assert foo_dict_list({'1': [dummy_object]}) is None
+        assert foo_dict_list({'1': [dummy_object, 'hi']}) is None
+
     def test_inherited_class_method(self):
         @typechecked
         class Parent:

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -19,7 +19,7 @@ from typing_extensions import NoReturn, Protocol, Literal, TypedDict, runtime_ch
 
 from typeguard import (
     typechecked, check_argument_types, qualified_name, TypeChecker, TypeWarning, function_name,
-    check_type, TypeHintWarning, ForwardRefPolicy, check_return_type)
+    check_type, TypeHintWarning, ForwardRefPolicy, check_return_type, typeguard_config)
 
 try:
     from typing import Collection
@@ -1162,9 +1162,10 @@ class TestTypeChecked:
             some_callable = CallableClass()
 
     def test_string_defined_class(self):
+        typeguard_config.postpone_evaluation = True
+
         @typechecked
         def foo(x: 'DummyClass') -> None:
-            assert check_argument_types()
             return None
 
         pytest.raises(TypeError, foo, Child())
@@ -1172,7 +1173,6 @@ class TestTypeChecked:
 
         @typechecked
         def foo_union(x: Union['DummyClass', str]) -> None:
-            assert check_argument_types()
             return None
 
         pytest.raises(TypeError, foo_union, Child())
@@ -1182,7 +1182,6 @@ class TestTypeChecked:
 
         @typechecked
         def foo_list(x: List[Union['DummyClass', str]]) -> None:
-            assert check_argument_types()
             return None
 
         pytest.raises(TypeError, foo_list, [1])
@@ -1194,7 +1193,6 @@ class TestTypeChecked:
 
         @typechecked
         def foo_dict(x: Dict[str, 'DummyClass']) -> None:
-            assert check_argument_types()
             return None
 
         pytest.raises(TypeError, foo_dict, {'1': Child()})
@@ -1203,7 +1201,6 @@ class TestTypeChecked:
 
         @typechecked
         def foo_dict_list(x: Dict[str, List[Union['DummyClass', str]]]) -> None:
-            assert check_argument_types()
             return None
 
         pytest.raises(TypeError, foo_dict_list, {'1': dummy_object})
@@ -1214,6 +1211,8 @@ class TestTypeChecked:
         assert foo_dict_list({'1': []}) is None
         assert foo_dict_list({'1': [dummy_object]}) is None
         assert foo_dict_list({'1': [dummy_object, 'hi']}) is None
+
+        typeguard_config.postpone_evaluation = False
 
     def test_inherited_class_method(self):
         @typechecked


### PR DESCRIPTION
Introduced module configuration. If ``typeguard_config.postpone_evaluation = True`` typeguard lets evaluate classes with null forward ref introduced by using ``TYPE_CHECKING``. Setting ``typeguard_config.postpone_evaluation = True`` is the same as importing ``from __future__ import annotation`` but checking object class. Fixes #168.

Postponing evaluation lets typecheck classes imported using ``TYPE_CHECKING``, see new tests:

```python
from typing import TYPE_CHECKING
from dummyclasses import dummy_object

if TYPE_CHECKING:
    from dummyclasses import DummyClass  # dummy_object = DummyClass()

...

def test_string_defined_class(self):
    if sys.version_info < (3, 7, 0):
        return

    typeguard_config.postpone_evaluation = True

    @typechecked
    def foo(x: 'DummyClass') -> None:
        return None

    pytest.raises(TypeError, foo, Child())
    assert foo(dummy_object) is None

    @typechecked
    def foo_union(x: Union['DummyClass', str]) -> None:
        return None

    pytest.raises(TypeError, foo_union, Child())
    pytest.raises(TypeError, foo_union, 1)
    assert foo_union(dummy_object) is None
    assert foo_union('hi') is None

    @typechecked
    def foo_list(x: List[Union['DummyClass', str]]) -> None:
        return None

    pytest.raises(TypeError, foo_list, [1])
    pytest.raises(TypeError, foo_list, [Child()])
    pytest.raises(TypeError, foo_list, [dummy_object, 1])
    assert foo_list([]) is None
    assert foo_list([dummy_object, 'object']) is None
    assert foo_list([dummy_object, dummy_object]) is None

    @typechecked
    def foo_dict(x: Dict[str, 'DummyClass']) -> None:
        return None

    pytest.raises(TypeError, foo_dict, {'1': Child()})
    pytest.raises(TypeError, foo_dict, {'1': 1})
    assert foo_dict({'1': dummy_object}) is None

    @typechecked
    def foo_dict_list(x: Dict[str, List[Union['DummyClass', str]]]) -> None:
        return None

    pytest.raises(TypeError, foo_dict_list, {'1': dummy_object})
    pytest.raises(TypeError, foo_dict_list, {'1': '1'})
    pytest.raises(TypeError, foo_dict_list, {'1': [1]})
    pytest.raises(TypeError, foo_dict_list, {'1': [dummy_object, 1]})
    pytest.raises(TypeError, foo_dict_list, {'1': ['1', 1]})
    assert foo_dict_list({'1': []}) is None
    assert foo_dict_list({'1': [dummy_object]}) is None
    assert foo_dict_list({'1': [dummy_object, 'hi']}) is None

    typeguard_config.postpone_evaluation = False

```

With ``typeguard_config.postpone_evaluation=False`` the test fails on each case, raising `NameError`. I know ``forward_refs_policy`` manages the behaviour of ``NameError``, but the current module architecture don't let to manage this issue.

By default ``typeguard_config.postpone_evaluation=False``; anyway it's safe to set as True as it does not break any test.

The biggest problem of this PR is:

1. Ignores the behaviour of ``forward_refs_policy``
2. Rewrites ``get_type_hints`` methods.
3. Only valid for py3.7+