### PR TITLE
Print complete `typing` type names

### DIFF
--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -111,7 +111,9 @@ def test_check_recursive_type():
     check_type('foo', {'a': [1, 2, 3]}, JSONType)
     pytest.raises(TypeError, check_type, 'foo', {'a': (1, 2, 3)}, JSONType, globals=globals()).\
         match(r'type of foo must be one of \(str, int, float, (bool, )?NoneType, '
-              r'List, Dict\); got dict instead')
+              r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
+              r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\); '
+              r'got dict instead')
 
 
 class TestCheckArgumentTypes:
@@ -456,6 +458,14 @@ class TestCheckArgumentTypes:
             'type of argument "a" must be one of (str, int); got {} instead'.
             format(value.__class__.__name__))
 
+    def test_union_generic_type_fail(self):
+        def foo(a: Union[None, List[int]]):
+            assert check_argument_types()
+
+        exc = pytest.raises(TypeError, foo, ["a"])
+        assert str(exc.value) == (
+            'type of argument "a" must be one of (NoneType, typing.List[int]); got list instead')
+
     @pytest.mark.parametrize('values', [
         (6, 7),
         ('aa', 'bb')
@@ -721,7 +731,13 @@ class TestCheckArgumentTypes:
         foo({'a': [1, 2, 3]})
         pytest.raises(TypeError, foo, {'a': (1, 2, 3)}).\
             match(r'type of argument "arg" must be one of \(str, int, float, (bool, )?NoneType, '
-                  r'List, Dict\); got dict instead')
+                  r'typing.List\[typing.Union\[str, int, float, (bool, )?NoneType, '
+                  r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
+                  r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\]\], '
+                  r'typing.Dict\[str, typing.Union\[str, int, float, (bool, )?NoneType, '
+                  r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
+                  r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\]\]\); '
+                  r'got dict instead')
 
 
 class TestTypeChecked:
@@ -1266,7 +1282,13 @@ class TestTypeChecked:
         foo({'a': [1, 2, 3]})
         pytest.raises(TypeError, foo, {'a': (1, 2, 3)}).\
             match(r'type of argument "arg" must be one of \(str, int, float, (bool, )?NoneType, '
-                  r'List, Dict\); got dict instead')
+                  r'typing.List\[typing.Union\[str, int, float, (bool, )?NoneType, '
+                  r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
+                  r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\]\], '
+                  r'typing.Dict\[str, typing.Union\[str, int, float, (bool, )?NoneType, '
+                  r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
+                  r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\]\]\); '
+                  r'got dict instead')
 
     def test_literal(self):
         from http import HTTPStatus

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -458,7 +458,7 @@ class TestCheckArgumentTypes:
             'type of argument "a" must be one of (str, int); got {} instead'.
             format(value.__class__.__name__))
 
-    def test_union_nested_type_fail(self):
+    def test_union_generic_type_fail(self):
         def foo(a: Union[None, List[int]]):
             assert check_argument_types()
 

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -111,8 +111,8 @@ def test_check_recursive_type():
     check_type('foo', {'a': [1, 2, 3]}, JSONType)
     pytest.raises(TypeError, check_type, 'foo', {'a': (1, 2, 3)}, JSONType, globals=globals()).\
         match(r'type of foo must be one of \(str, int, float, (bool, )?NoneType, '
-              r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
-              r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\); '
+              r'typing.List\[_?ForwardRef\(\'JSONType\'\)\], '
+              r'typing.Dict\[str, _?ForwardRef\(\'JSONType\'\)\]\); '
               r'got dict instead')
 
 
@@ -458,7 +458,7 @@ class TestCheckArgumentTypes:
             'type of argument "a" must be one of (str, int); got {} instead'.
             format(value.__class__.__name__))
 
-    def test_union_generic_type_fail(self):
+    def test_union_nested_type_fail(self):
         def foo(a: Union[None, List[int]]):
             assert check_argument_types()
 
@@ -732,11 +732,11 @@ class TestCheckArgumentTypes:
         pytest.raises(TypeError, foo, {'a': (1, 2, 3)}).\
             match(r'type of argument "arg" must be one of \(str, int, float, (bool, )?NoneType, '
                   r'typing.List\[typing.Union\[str, int, float, (bool, )?NoneType, '
-                  r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
-                  r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\]\], '
+                  r'typing.List\[_?ForwardRef\(\'JSONType\'\)\], '
+                  r'typing.Dict\[str, _?ForwardRef\(\'JSONType\'\)\]\]\], '
                   r'typing.Dict\[str, typing.Union\[str, int, float, (bool, )?NoneType, '
-                  r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
-                  r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\]\]\); '
+                  r'typing.List\[_?ForwardRef\(\'JSONType\'\)\], '
+                  r'typing.Dict\[str, _?ForwardRef\(\'JSONType\'\)\]\]\]\); '
                   r'got dict instead')
 
 
@@ -1283,11 +1283,11 @@ class TestTypeChecked:
         pytest.raises(TypeError, foo, {'a': (1, 2, 3)}).\
             match(r'type of argument "arg" must be one of \(str, int, float, (bool, )?NoneType, '
                   r'typing.List\[typing.Union\[str, int, float, (bool, )?NoneType, '
-                  r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
-                  r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\]\], '
+                  r'typing.List\[_?ForwardRef\(\'JSONType\'\)\], '
+                  r'typing.Dict\[str, _?ForwardRef\(\'JSONType\'\)\]\]\], '
                   r'typing.Dict\[str, typing.Union\[str, int, float, (bool, )?NoneType, '
-                  r'typing.List\[ForwardRef\(\'JSONType\'\)\], '
-                  r'typing.Dict\[str, ForwardRef\(\'JSONType\'\)\]\]\]\); '
+                  r'typing.List\[_?ForwardRef\(\'JSONType\'\)\], '
+                  r'typing.Dict\[str, _?ForwardRef\(\'JSONType\'\)\]\]\]\); '
                   r'got dict instead')
 
     def test_literal(self):

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -184,7 +184,7 @@ def resolve_forwardref(maybe_ref, memo: _TypeCheckMemo):
 
 def get_type_name(type_):
     # typing.* types don't have a __name__ on Python 3.7+
-    return getattr(type_, '__name__', None) or getattr(type_, '_name', None) or str(type_)
+    return getattr(type_, '__name__', None) or str(type_)
 
 
 def find_function(frame) -> Optional[Callable]:

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -6,8 +6,6 @@ import gc
 import inspect
 import sys
 import threading
-import typing
-import typing_extensions
 from collections import OrderedDict
 from enum import Enum
 from functools import wraps, partial
@@ -18,10 +16,15 @@ from types import CodeType, FunctionType
 from typing import (
     Callable, Any, Union, Dict, List, TypeVar, Tuple, Set, Sequence, get_type_hints, TextIO,
     Optional, IO, BinaryIO, Type, Generator, overload, Iterable, AsyncIterable, Iterator,
-    AsyncIterator, AbstractSet)
+    AsyncIterator, AbstractSet, __name__ as _typing_module_name)
 from unittest.mock import Mock
 from warnings import warn
 from weakref import WeakKeyDictionary, WeakValueDictionary
+
+try:
+    from typing_extensions import __name__ as _typing_ext_module_name
+except ImportError:
+    _typing_ext_module_name = None
 
 # Python 3.8+
 try:
@@ -185,7 +188,7 @@ def resolve_forwardref(maybe_ref, memo: _TypeCheckMemo):
 
 
 def get_type_name(type_):
-    if type_.__module__ in [typing.__name__, typing_extensions.__name__]:
+    if type_.__module__ == _typing_module_name or type_.__module__ == _typing_ext_module_name:
         return str(type_)  # __repr__ of `typing` types is more detailed than __name__
 
     return getattr(type_, '__name__', None) or str(type_)

--- a/typeguard/__init__.py
+++ b/typeguard/__init__.py
@@ -6,6 +6,8 @@ import gc
 import inspect
 import sys
 import threading
+import typing
+import typing_extensions
 from collections import OrderedDict
 from enum import Enum
 from functools import wraps, partial
@@ -183,7 +185,9 @@ def resolve_forwardref(maybe_ref, memo: _TypeCheckMemo):
 
 
 def get_type_name(type_):
-    # typing.* types don't have a __name__ on Python 3.7+
+    if type_.__module__ in [typing.__name__, typing_extensions.__name__]:
+        return str(type_)  # __repr__ of `typing` types is more detailed than __name__
+
     return getattr(type_, '__name__', None) or str(type_)
 
 


### PR DESCRIPTION
This partially addresses the existing problem with type erasure while checking Union Types reported in https://github.com/agronholm/typeguard/issues/65

Currently, for this code example:
```
from typeguard import typechecked
from typing import Optional, List

@typechecked
def myfun(arg: Optional[List[int]]) -> List[int]:
    return arg or []

myfun(["a"])
```

`typeguard` returns the following error, which is not very descriptive and can be quite ambiguous to users of the library being developed:
```
TypeError: type of argument "arg" must be one of (List, NoneType); got list instead
```

After the proposed change in this PR it returns the more descriptive error:
```
TypeError: type of argument "arg" must be one of (typing.List[int], NoneType); got list instead
```

Even though this does not completely resolve the Union issue in https://github.com/agronholm/typeguard/issues/65, it significantly reduces the ambiguity caused by it.