### PR TITLE
Add ability to override typeguard default checks

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,7 @@ API reference
 
 .. autofunction:: register_override
 
+.. autofunction:: remove_override
 
 :mod:`typeguard.importhook`
 ---------------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,6 +25,9 @@ API reference
 .. autoclass:: ForwardRefPolicy
     :members:
 
+.. autofunction:: register_override
+
+
 :mod:`typeguard.importhook`
 ---------------------------
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -230,3 +230,27 @@ Type            Notes
 
 .. _#101: https://github.com/agronholm/typeguard/issues/101
 .. _issue 42059: https://bugs.python.org/issue42059
+
+Overriding default checking
+---------------------------
+
+Occasionally, a project might need to override typeguard's default checking
+behaviour for a specific type.
+
+The `register_override` function provides the user the ability to submit a
+function that performs the type check for a given type.
+The override is type specific, subtypes of that type will not be affected.
+
+Overriding type checking can be necessary when working with libraries that
+rely on duck typing, without making that behaviour explicit in their
+type annotations. For example, Numpy has several integer types (e.g. `int64`)
+which are treated as equivalent to Python's built-in `int`. However, using
+them as equivalent will lead to typeguard raising an error about `int64` and
+`int` not being the same type.
+
+Example: overriding `int` checking to accept numpy integers.
+.. code-block:: python
+
+   def check_int(argname: str, value: Any, expected_type: Any, memo: Any):
+       if expected_type is int and not isinstance(value, (int, np.signedinteger)):
+           raise TypeError('type of {} must be either python int or numpy int: got {} instead'.format(argname, value.__class__))

--- a/src/typeguard/__init__.py
+++ b/src/typeguard/__init__.py
@@ -99,7 +99,8 @@ def register_override(expected_type: Type,
 
        def check_int(argname: str, value: Any, expected_type: Any, memo: Any):
            if expected_type is int and not isinstance(value, (int, np.signedinteger)):
-               raise TypeError('type of {} must be either python int or numpy int: got {} instead'.format(argname, value.__class__))
+               raise TypeError('type of {} must be either python or numpy int: got {} instead'
+               .format(argname, value.__class__))
 
     """
     _overrides[expected_type] = check_function

--- a/src/typeguard/__init__.py
+++ b/src/typeguard/__init__.py
@@ -75,7 +75,7 @@ else:
 _type_hints_map = WeakKeyDictionary()  # type: Dict[FunctionType, Dict[str, Any]]
 _functions_map = WeakValueDictionary()  # type: Dict[CodeType, FunctionType]
 _missing = object()
-_overrides = {} # type: Dict[Type, Callable[[str, Any, Any, Any], None]]
+_overrides = {}  # type: Dict[Type, Callable[[str, Any, Any, Any], None]]
 
 T_CallableOrType = TypeVar('T_CallableOrType', bound=Callable[..., Any])
 

--- a/src/typeguard/__init__.py
+++ b/src/typeguard/__init__.py
@@ -75,7 +75,7 @@ else:
 _type_hints_map = WeakKeyDictionary()  # type: Dict[FunctionType, Dict[str, Any]]
 _functions_map = WeakValueDictionary()  # type: Dict[CodeType, FunctionType]
 _missing = object()
-_overrides = {}
+_overrides: Dict[Type, Callable[[str, Any, Any, Any], None]] = {}
 
 T_CallableOrType = TypeVar('T_CallableOrType', bound=Callable[..., Any])
 

--- a/src/typeguard/__init__.py
+++ b/src/typeguard/__init__.py
@@ -75,7 +75,7 @@ else:
 _type_hints_map = WeakKeyDictionary()  # type: Dict[FunctionType, Dict[str, Any]]
 _functions_map = WeakValueDictionary()  # type: Dict[CodeType, FunctionType]
 _missing = object()
-_overrides: Dict[Type, Callable[[str, Any, Any, Any], None]] = {}
+_overrides = {} # type: Dict[Type, Callable[[str, Any, Any, Any], None]]
 
 T_CallableOrType = TypeVar('T_CallableOrType', bound=Callable[..., Any])
 
@@ -104,6 +104,12 @@ def register_override(expected_type: Type,
 
     """
     _overrides[expected_type] = check_function
+
+
+def remove_override(expected_type: Type):
+    """ Restore default checking behaviour for the specified type
+    """
+    del _overrides[expected_type]
 
 
 class ForwardRefPolicy(Enum):

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -15,7 +15,7 @@ from typing_extensions import NoReturn, Protocol, Literal, TypedDict, runtime_ch
 
 from typeguard import (
     typechecked, check_argument_types, qualified_name, TypeChecker, TypeWarning, function_name,
-    check_type, TypeHintWarning, ForwardRefPolicy, check_return_type, register_override)
+    check_type, TypeHintWarning, ForwardRefPolicy, check_return_type, register_override, remove_override)
 
 try:
     from typing import Collection
@@ -1535,3 +1535,5 @@ class TestOverride:
 
         register_override(int, no_check)
         foo(1.2)
+        remove_override(int)
+

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -15,7 +15,7 @@ from typing_extensions import NoReturn, Protocol, Literal, TypedDict, runtime_ch
 
 from typeguard import (
     typechecked, check_argument_types, qualified_name, TypeChecker, TypeWarning, function_name,
-    check_type, TypeHintWarning, ForwardRefPolicy, check_return_type)
+    check_type, TypeHintWarning, ForwardRefPolicy, check_return_type, register_override)
 
 try:
     from typing import Collection
@@ -1521,3 +1521,16 @@ class TestTracebacks:
             typeguard_lines = [part for part in parts
                                if part.filename.endswith("typeguard/__init__.py")]
             assert len(typeguard_lines) == 1
+
+class TestOverride:
+    def test_override(self):
+
+        def foo(x:int):
+            assert check_argument_types()
+            return x
+
+        def no_check(*args):
+            return
+
+        register_override(int, no_check)
+        foo(1.2)

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -15,7 +15,8 @@ from typing_extensions import NoReturn, Protocol, Literal, TypedDict, runtime_ch
 
 from typeguard import (
     typechecked, check_argument_types, qualified_name, TypeChecker, TypeWarning, function_name,
-    check_type, TypeHintWarning, ForwardRefPolicy, check_return_type, register_override, remove_override)
+    check_type, TypeHintWarning, ForwardRefPolicy, check_return_type, register_override,
+    remove_override)
 
 try:
     from typing import Collection
@@ -1536,4 +1537,3 @@ class TestOverride:
         register_override(int, no_check)
         foo(1.2)
         remove_override(int)
-

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1522,10 +1522,11 @@ class TestTracebacks:
                                if part.filename.endswith("typeguard/__init__.py")]
             assert len(typeguard_lines) == 1
 
+
 class TestOverride:
     def test_override(self):
 
-        def foo(x:int):
+        def foo(x: int):
             assert check_argument_types()
             return x
 


### PR DESCRIPTION
This PR is related to the question here: https://github.com/agronholm/typeguard/issues/184

After following the path of adding `Union[int, np.int64]` everywhere, which fixed the problem with typeguard, now I have 30 issues with mypy because `np.int64` behaves as an int (so it can be passed to `range` for example) but mypy will complain if a variable which is typed `Union[int, np.int64]` is passed to `range`.

This PR allows the user to provide a function that, for example, makes typeguard treat `np.int64` as `int`.

[x] added function register_override
[x] added tests
[x] extended docs