### PR TITLE
Fix `AttributeError` when `__code__` is missing from the checked callable

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,10 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
+**UNRELEASED**
+
+- Ensure __code__ is available on function type checking (PR by epenet)
+
 **2.12.0** (2021-04-01)
 
 - Added ``@typeguard_ignore`` decorator to exclude specific functions and classes from

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,7 +5,7 @@ This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-v
 
 **UNRELEASED**
 
-- Ensure __code__ is available on function type checking (PR by epenet)
+- Fixed ``AttributeError`` when ``__code__`` is missing from the checked callable (PR by epenet)
 
 **2.12.0** (2021-04-01)
 

--- a/src/typeguard/__init__.py
+++ b/src/typeguard/__init__.py
@@ -917,6 +917,10 @@ def typechecked(func=None, *, always=False, _localns: Optional[Dict[str, Any]] =
     # Find either the first Python wrapper or the actual function
     python_func = inspect.unwrap(func, stop=lambda f: hasattr(f, '__code__'))
 
+    if not getattr(python_func, '__code__', None):
+        warn('no code associated -- not typechecking {}'.format(function_name(func)))
+        return func
+
     def wrapper(*args, **kwargs):
         memo = _CallMemo(python_func, _localns, args=args, kwargs=kwargs)
         check_argument_types(memo)

--- a/src/typeguard/__init__.py
+++ b/src/typeguard/__init__.py
@@ -906,16 +906,16 @@ def typechecked(func=None, *, always=False, _localns: Optional[Dict[str, Any]] =
 
         return func
 
+    if not getattr(func, '__annotations__', None):
+        warn('no type annotations present -- not typechecking {}'.format(function_name(func)))
+        return func
+
     # Find the frame in which the function was declared, for resolving forward references later
     if _localns is None:
         _localns = sys._getframe(1).f_locals
 
     # Find either the first Python wrapper or the actual function
     python_func = inspect.unwrap(func, stop=lambda f: hasattr(f, '__code__'))
-
-    if not getattr(func, '__annotations__', None):
-        warn('no type annotations present -- not typechecking {}'.format(function_name(func)))
-        return func
 
     def wrapper(*args, **kwargs):
         memo = _CallMemo(python_func, _localns, args=args, kwargs=kwargs)

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1507,6 +1507,24 @@ class TestTypeChecker:
         assert str(record[0].message).startswith("Replaced forward declaration 'OrderedDict' in")
         assert unresolvable_annotation.__annotations__['x'] is collections.OrderedDict
 
+    def test_callable(self):
+        class command:
+            # we need an __annotations__ attribute to trigger the code path
+            whatever: float
+
+            def __init__(self, function: Callable[[int], int]):
+                self.function = function
+
+            def __call__(self, arg: int) -> None:
+                self.function(arg)
+
+        @typechecked
+        @command
+        def function(arg: int) -> None:
+            pass
+
+        function(1)
+
 
 class TestTracebacks:
     def test_short_tracebacks(self):

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1507,24 +1507,6 @@ class TestTypeChecker:
         assert str(record[0].message).startswith("Replaced forward declaration 'OrderedDict' in")
         assert unresolvable_annotation.__annotations__['x'] is collections.OrderedDict
 
-    def test_callable(self):
-        class command:
-            # we need an __annotations__ attribute to trigger the code path
-            whatever: float
-
-            def __init__(self, function: Callable[[int], int]):
-                self.function = function
-
-            def __call__(self, arg: int) -> None:
-                self.function(arg)
-
-        @typechecked
-        @command
-        def function(arg: int) -> None:
-            pass
-
-        function(1)
-
 
 class TestTracebacks:
     def test_short_tracebacks(self):

--- a/tests/test_typeguard_py36.py
+++ b/tests/test_typeguard_py36.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import AsyncGenerator, AsyncIterable, AsyncIterator
+from typing import AsyncGenerator, AsyncIterable, AsyncIterator, Callable
 
 import pytest
 from typing_extensions import Protocol, runtime_checkable

--- a/tests/test_typeguard_py36.py
+++ b/tests/test_typeguard_py36.py
@@ -135,6 +135,24 @@ class TestTypeChecker:
 
         assert len(record) == 0
 
+    def test_callable(self):
+        class command:
+            # we need an __annotations__ attribute to trigger the code path
+            whatever: float
+
+            def __init__(self, function: Callable[[int], int]):
+                self.function = function
+
+            def __call__(self, arg: int) -> None:
+                self.function(arg)
+
+        @typechecked
+        @command
+        def function(arg: int) -> None:
+            pass
+
+        function(1)
+
 
 def test_protocol_non_method_members():
     @typechecked


### PR DESCRIPTION
Fixes: #191

When using https://github.com/pallets/click, the `@click.group()` function decorator return a class instance (`click.core.<Group xyz>`) which does not have associated code. This causes Typeguard to fail with `AttributeError: 'Group' object has no attribute '__code__'`.