### PR TITLE
Fix __module__ default when run in an exec

### DIFF
--- a/src/typeguard/__init__.py
+++ b/src/typeguard/__init__.py
@@ -334,7 +334,8 @@ def function_name(func: Callable) -> str:
 
     """
     # For partial functions and objects with __call__ defined, __qualname__ does not exist
-    module = getattr(func, '__module__', '')
+    # For functions run in `exec` with a custom namespace, __module__ can be None
+    module = getattr(func, '__module__', '') or ''
     qualname = (module + '.') if module not in ('builtins', '') else ''
     return qualname + getattr(func, '__qualname__', repr(func))
 

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -147,6 +147,18 @@ def test_check_recursive_type():
         match(r'type of foo must be one of \(str, int, float, (bool, )?NoneType, '
               r'List\[JSONType\], Dict\[str, JSONType\]\); got dict instead')
 
+def test_exec_no_namespace():
+    from textwrap import dedent
+
+    exec(dedent("""
+        from typeguard import typechecked
+
+        @typechecked
+        def f():
+            pass
+
+        """), {})
+
 
 class TestCheckArgumentTypes:
     def test_any_type(self):

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -147,6 +147,7 @@ def test_check_recursive_type():
         match(r'type of foo must be one of \(str, int, float, (bool, )?NoneType, '
               r'List\[JSONType\], Dict\[str, JSONType\]\); got dict instead')
 
+
 def test_exec_no_namespace():
     from textwrap import dedent
 


### PR DESCRIPTION
Running typeguard 2.13 in an exec with an empty environment errors. This PR fixes that by mapping a `f.__module__` of `None` to the empty string.

```
exec("""
from typeguard import typechecked

@typechecked
def f():
   pass

""", {})
```

(The root issue is that this exec-in-empty-namespace thing is what doctests like to do)