### PR TITLE
fix flaky test on test_typeguard.py::test_check_call_args and potential bug report on test_typeguard.py

### DIFF
--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1395,7 +1395,7 @@ class TestTypeChecker:
         assert len(record) == 1
         warning = record[0].message
         assert warning.error == 'type of argument "a" must be int; got str instead'
-        assert warning.func is foo
+        assert warning.func.__closure__ is foo.__closure__
         assert isinstance(warning.stack, list)
         buffer = StringIO()
         warning.print_stack(buffer)


### PR DESCRIPTION
This PR aims to fix the flaky test on `test_typeguard.py::test_check_call_args`  so the test could pass single run, multiple test run, and random test run. Additionally, I also detect two potential bugs in `test_typeguard.py`

#### The result

The test will fail on the multipe re-runs with pytest flake-finder, the following error will raised start on the second test run
`tests/test_typeguard.py:1398: in test_check_call_args`
`    assert warning.func is foo`
`E   assert <function TestTypeChecker.test_check_call_args.<locals>.foo at 0x7fe72c591598> is <function TestTypeChecker.test_check_call_args.<locals>.foo at 0x7fe72c688c80>`
`E    +  where <function TestTypeChecker.test_check_call_args.<locals>.foo at 0x7fe72c591598> = TypeWarning('[MainThread] call to test_typeguard.TestTypeChecker.test_check_call_args.<locals>.foo() from /typeguard/tests/test_typeguard.py:1390: type of argument "a" must be int; got str instead',).func`


#### Steps to reproduce the issue

1.  install pytest flaky finder with `pip install pytest-flakefinder`
2.  run pytest with flake-finder with command  `pytest -k tests/test_typeguard.py --flake-finder`

#### Issue of the code

The reason is that the nested class `foo` created in the test_typeguard.py will also be created each time when re-run the test, and the original assertion `assert warning.func is foo`  will confused and mismatch the nested class 

#### Proposed solution
Using `assert warning.func.__closure__ is foo.__closure__` instead of assertion just on function name, which will be referred to shadow nested class so it will now pass multipe runs.

