### PR TITLE
Avoid no-any-return in `typeguard._exeptions.TypeCheckError.__str__`

### DIFF
--- a/src/typeguard/_exceptions.py
+++ b/src/typeguard/_exceptions.py
@@ -29,7 +29,9 @@ class TypeCheckError(Exception):
         self._path.append(element)
 
     def __str__(self) -> str:
-        if self._path:
-            return " of ".join(self._path) + " " + self.args[0]
+        if len(self.args) == 0:
+            raise ValueError("No args are given.")
+        elif self._path:
+            return " of ".join(self._path) + f" {self.args[0]}"
         else:
-            return self.args[0]
+            return f"{self.args[0]}"


### PR DESCRIPTION
`mypy --strict` says:

```
src/typeguard/_exceptions.py:33: error: Returning Any from function declared to
return "str"  [no-any-return]
                return " of ".join(self._path) + " " + self.args[0]
                ^
src/typeguard/_exceptions.py:35: error: Returning Any from function declared to
return "str"  [no-any-return]
                return self.args[0]
                ^
```

If `self.args` is an empty tuple, it raises `IndexError`. So I add:

```python
if len(self.args) == 0:
    raise ValueError("No args are given.")
```