### PR TITLE
Handles type checks for Type[Protocol]

### DIFF
--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -376,7 +376,9 @@ def check_class(
         return
 
     expected_class = args[0]
-    if isinstance(expected_class, TypeVar):
+    if getattr(expected_class, "_is_protocol", False):
+        check_protocol(value, expected_class, (), memo)
+    elif isinstance(expected_class, TypeVar):
         check_typevar(value, expected_class, (), memo, subclass_check=True)
     elif get_origin(expected_class) is Union:
         errors: Dict[str, TypeCheckError] = {}
@@ -501,6 +503,12 @@ def check_protocol(
             raise TypeCheckError(
                 f"is not compatible with the {origin_type.__qualname__} protocol"
             )
+    else:
+        warnings.warn(
+            "Typeguard cannot check the {} protocol because it is a non-runtime protocol. "
+            "If you would like to type check this protocol, "
+            "please use @typing.runtime_checkable".format(origin_type.__qualname__)
+        )
 
 
 def check_byteslike(

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -505,9 +505,9 @@ def check_protocol(
             )
     else:
         warnings.warn(
-            "Typeguard cannot check the {} protocol because it is a non-runtime protocol. "
-            "If you would like to type check this protocol, "
-            "please use @typing.runtime_checkable".format(origin_type.__qualname__)
+            f"Typeguard cannot check the {origin_type.__qualname__} protocol because "
+            f"it is a non-runtime protocol. If you would like to type check this "
+            f"protocol, please use @typing.runtime_checkable"
         )
 
 


### PR DESCRIPTION
I noticed that typeguard wasn't able to correctly type check passed in classes when the type hint was a Type[Protocol]. You would receive an error like: `TypeError: Protocols with non-method members don't support issubclass()`. Using isinstance() in these situations would be able to correctly type check the passed in class. I also added a warning when a Protocol wasn't annotated with runtime_checkable to make it more explicit when typeguard was unable to perform type checking.

Tests: 
Added a data protocol to improve coverage
Added a test for checking Type[Protocol]