### PR TITLE
Add Required/NotRequired typing

### DIFF
--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -2,6 +2,7 @@ import collections.abc
 import inspect
 import sys
 import types
+import typing_extensions
 import warnings
 from enum import Enum
 from inspect import Parameter, isclass, isfunction
@@ -200,12 +201,19 @@ def check_mapping(
 def check_typed_dict(
     value: Any, origin_type: Any, args: Tuple[Any, ...], memo: TypeCheckMemo
 ) -> None:
+    typ_not_required = typing_extensions.NotRequired
     declared_keys = frozenset(origin_type.__annotations__)
+    
+    not_required = [key for key, argtype in get_type_hints(origin_type).items() if typ_not_required == typing_extensions.get_origin(argtype)]
+    
     if hasattr(origin_type, "__required_keys__"):
         required_keys = origin_type.__required_keys__
     else:  # py3.8 and lower
         required_keys = declared_keys if origin_type.__total__ else frozenset()
 
+    if origin_type.__total__:
+        required_keys = frozenset([i for i in required_keys if i not in not_required])
+        
     existing_keys = frozenset(value)
     extra_keys = existing_keys - declared_keys
     if extra_keys:
@@ -213,6 +221,7 @@ def check_typed_dict(
         raise TypeCheckError(f"has unexpected extra key(s): {keys_formatted}")
 
     missing_keys = required_keys - existing_keys
+    
     if missing_keys:
         keys_formatted = ", ".join(f'"{key}"' for key in sorted(missing_keys))
         raise TypeCheckError(f"is missing required key(s): {keys_formatted}")
@@ -347,7 +356,6 @@ def check_union(
     )
     raise TypeCheckError(f"did not match any element in the union:\n{formatted_errors}")
 
-
 def check_uniontype(
     value: Any, origin_type: Any, args: Tuple[Any, ...], memo: TypeCheckMemo
 ) -> None:
@@ -470,8 +478,19 @@ def check_literal(
     if value not in final_args:
         formatted_args = ", ".join(repr(arg) for arg in final_args)
         raise TypeCheckError(f"is not any of ({formatted_args})")
-
-
+    
+def check_not_required(
+    value: Any, origin_type: Any, args: Tuple[Any, ...], memo: TypeCheckMemo
+) -> None:
+    for type_ in args:
+        check_type_internal(value, type_, memo)
+        
+def check_required(
+    value: Any, origin_type: Any, args: Tuple[Any, ...], memo: TypeCheckMemo
+) -> None:
+    check_not_required(value, origin_type, args, memo)
+        
+        
 def check_number(
     value: Any, origin_type: Any, args: Tuple[Any, ...], memo: TypeCheckMemo
 ) -> None:
@@ -523,8 +542,7 @@ def check_instanceof(
 ) -> None:
     if not isinstance(value, origin_type):
         raise TypeCheckError(f"is not an instance of {qualified_name(origin_type)}")
-
-
+    
 def check_type_internal(value: Any, annotation: Any, memo: TypeCheckMemo) -> None:
     from . import ForwardRefPolicy, config
 
@@ -595,6 +613,8 @@ origin_type_checkers = {
     type: check_class,
     Type: check_class,
     Union: check_union,
+    typing_extensions.NotRequired : check_not_required,
+    typing_extensions.Required : check_required
 }
 if sys.version_info >= (3, 10):
     origin_type_checkers[types.UnionType] = check_uniontype


### PR DESCRIPTION
Hello Team, 

I add Required/NotRequired from typing_extensions, doesn't change the comportement of typechecked when you use total=False, but when you use total=True, the code check if we use NotRequired and doesn't flag the keys like an required_keys. I hope this fork can be usefull for another user.


Example : 
```
from dataclasses import dataclass, field
from typing import *
from typeguard import typechecked
from typing_extensions import NotRequired, Required 

@dataclass
class Fields():
    """Metadata for the request
    """
    asset: Required[List[str]] = field(default_factory=['X478'])
    type_asset: NotRequired[List[str]] = field(default_factory="")

@typechecked
def test_toto(params: TypedDict("params",Fields.__annotations__, total = True)):
    pass

test_toto(params = {"asset" : ["10"]})
test_toto(params = {"asset" : ["10"], "type_asset" : [10]})

```