### PR TITLE
fixed some checks for ANY

### DIFF
--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -376,7 +376,9 @@ def check_class(
         return
 
     expected_class = args[0]
-    if getattr(expected_class, "_is_protocol", False):
+    if expected_class is Any:
+        return
+    elif getattr(expected_class, "_is_protocol", False):
         check_protocol(value, expected_class, (), memo)
     elif isinstance(expected_class, TypeVar):
         check_typevar(value, expected_class, (), memo, subclass_check=True)
@@ -540,6 +542,9 @@ def check_type_internal(value: Any, annotation: Any, memo: TypeCheckMemo) -> Non
                 )
 
             return
+
+    if annotation is Any:
+        return
 
     extras: Tuple[Any, ...]
     origin_type = get_origin(annotation)

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -290,6 +290,9 @@ class TestMapping:
             TypeCheckError, check_type, TestMapping.DummyMapping(), Mapping[str, str]
         ).match(r"value of key 'a' of value is not an instance of str")
 
+    def test_any_value_type(self):
+        check_type(TestMapping.DummyMapping(), Mapping[str, Any])
+
 
 class TestMutableMapping:
     class DummyMutableMapping(collections.abc.MutableMapping):
@@ -616,6 +619,9 @@ class TestType:
 
     def test_union_any(self):
         check_type(list, Type[Union[str, int, Any]])
+        
+    def test_any(self):
+        check_type(list, Type[Any])
 
     def test_union_fail(self):
         pytest.raises(

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -619,7 +619,7 @@ class TestType:
 
     def test_union_any(self):
         check_type(list, Type[Union[str, int, Any]])
-        
+
     def test_any(self):
         check_type(list, Type[Any])
 

--- a/tests/test_typechecked.py
+++ b/tests/test_typechecked.py
@@ -47,7 +47,7 @@ class TestCoroutineFunction:
         @typechecked
         async def foo() -> Any:
             return 1
-        
+
         assert asyncio.run(foo()) == 1
 
 

--- a/tests/test_typechecked.py
+++ b/tests/test_typechecked.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import (
+    Any,
     AsyncGenerator,
     AsyncIterable,
     AsyncIterator,
@@ -41,6 +42,13 @@ class TestCoroutineFunction:
             TypeCheckError, match="return value is not an instance of str"
         ):
             asyncio.run(foo(1))
+
+    def test_any_return(self):
+        @typechecked
+        async def foo() -> Any:
+            return 1
+        
+        assert asyncio.run(foo()) == 1
 
 
 class TestGenerator:


### PR DESCRIPTION
Typeguard currently fails on checks of : 

* returning Any
* Mapping with key or value annotated as Any
* Type[Any]

maybe more.

For the previous two, it uses `type_check_internal`, which does not check `Any`. The program tries to check for `Any` before calling `type_check_intenal`, but fails to do so in all places. I think it may be better to check for `Any` inside `type_check_internal`, because `Any` should be checked on every call site of `type_check_internal`.

The last is handled by `check_class`. `check_class` handled `Type[Union[Any]]`, but not `Type[Any]`.