### PR TITLE
optionally allow extra keys in typed dicts via check_type

### DIFF
--- a/src/typeguard/__init__.py
+++ b/src/typeguard/__init__.py
@@ -71,6 +71,7 @@ def check_type(
     expected_type: Any,
     *,
     argname: str = "value",
+    allow_extra: bool = False,
     memo: Optional[TypeCheckMemo] = None,
 ) -> None:
     """
@@ -83,6 +84,7 @@ def check_type(
     :param value: value to be checked against ``expected_type``
     :param expected_type: a class or generic type instance
     :param argname: name of the argument to check; used for error messages
+    :param allow_extra: allow extra fields when checking TypedDict's
     :raises TypeCheckError: if there is a type mismatch
 
     """
@@ -94,7 +96,7 @@ def check_type(
         memo = TypeCheckMemo(frame.f_globals, frame.f_locals)
 
     try:
-        check_type_internal(value, expected_type, memo)
+        check_type_internal(value, expected_type, memo, allow_extra=allow_extra)
     except TypeCheckError as exc:
         exc.append_path_element(argname)
         if memo.config.typecheck_fail_callback:

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -391,6 +391,15 @@ class TestTypedDict:
         else:
             check_type(value, DummyDict)
 
+    def test_typed_dict_with_extra_keys(self):
+        class DummyDict(TypedDict):
+            x: int
+            y: str
+
+        value = {"x": 6, "y": "foo", "bar": "abc"}
+
+        check_type(value, DummyDict, allow_extra=True)
+
 
 class TestList:
     def test_valid(self):


### PR DESCRIPTION
## What 

This PR:
- adds an optional kwarg `allow_extra` to `check_type`
- `allow_extra` defaults to `False`
- if `allow_extra` is `True`, any `TypedDict` checks will allow extra keys over `value`, rather than raise a `TypeCheckError`

## Why 

After reading https://github.com/python/mypy/issues/4617, it does not appear that `TypedDict` will allow extra keys (fields) any time soon.

I like to use `typeguard` to validate data coming from outside process bounds. I use `check_type` for that. This lets me re-use the Python type hints already specified in the code base. This is better (IMO) than specifying things a second time with, say, Pydantic, or Marshmallow. In most cases this data is JSON, and most of the time it's envelope'd into a dictionary.