### PR TITLE
Fixed an exception when a dict has mixed bytes and str keys

### DIFF
--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -200,6 +200,12 @@ def check_mapping(
 def check_typed_dict(
     value: Any, origin_type: Any, args: Tuple[Any, ...], memo: TypeCheckMemo
 ) -> None:
+    def sorted_dict(value):
+        try:
+            return sorted(value)
+        except TypeError:
+            return value
+
     declared_keys = frozenset(origin_type.__annotations__)
     if hasattr(origin_type, "__required_keys__"):
         required_keys = origin_type.__required_keys__
@@ -209,12 +215,12 @@ def check_typed_dict(
     existing_keys = frozenset(value)
     extra_keys = existing_keys - declared_keys
     if extra_keys:
-        keys_formatted = ", ".join(f'"{key}"' for key in sorted(extra_keys))
+        keys_formatted = ", ".join(f'"{key}"' for key in sorted_dict(extra_keys))
         raise TypeCheckError(f"has unexpected extra key(s): {keys_formatted}")
 
     missing_keys = required_keys - existing_keys
     if missing_keys:
-        keys_formatted = ", ".join(f'"{key}"' for key in sorted(missing_keys))
+        keys_formatted = ", ".join(f'"{key}"' for key in sorted_dict(missing_keys))
         raise TypeCheckError(f"is missing required key(s): {keys_formatted}")
 
     for key, argtype in get_type_hints(origin_type).items():

--- a/tests/test_inline.py
+++ b/tests/test_inline.py
@@ -11,6 +11,11 @@ if sys.version_info >= (3, 9):
 else:
     from typing_extensions import Annotated
 
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
 
 class TestCheckArgumentTypes:
     def test_valid(self):
@@ -97,4 +102,17 @@ class TestCheckReturnType:
 
         pytest.raises(TypeCheckError, foo).match(
             "the return value is not an instance of bool"
+        )
+
+    def test_inconsistent_keys_invalid(self):
+        class DummyDict(TypedDict):
+            x: int
+
+        def return_inconsistent_keys() -> DummyDict:
+            check_return_type({"x": 1, "y": 2, b"z": 3})
+            return {"x": 1, "y": 2, b"z": 3}
+
+        pytest.raises(TypeCheckError, return_inconsistent_keys).match(
+            r'the return value has unexpected extra key\(s\): ("y", "b\'z\'"|"b\'z\'",'
+            r' "y")'
         )


### PR DESCRIPTION
The following code demonstrates the problem that is fixed by this PR:

```python
from typing import TypedDict

from typeguard import typechecked

class TestDict(TypedDict):
    a: str

@typechecked
def test() -> TestDict:
    return {
        'str': 'test',
        b'bytes': 'test'
    }

test()
```

```
$ ./test.py 
Traceback (most recent call last):
  File "/home/ldef/typeguard/src/./test.py", line 16, in <module>
    test()
  File "/home/ldef/typeguard/src/typeguard/__init__.py", line 285, in wrapper
    check_return_type(retval, memo)
  File "/home/ldef/typeguard/src/typeguard/__init__.py", line 172, in check_return_type
    check_type_internal(retval, memo.type_hints["return"], memo)
  File "/home/ldef/typeguard/src/typeguard/_checkers.py", line 568, in check_type_internal
    checker(value, origin_type, args, memo)
  File "/home/ldef/typeguard/src/typeguard/_checkers.py", line 220, in check_typed_dict
    raise TypeCheckError(f"has unexpected extra key(s): {keys_formatted}")
typeguard._exceptions.TypeCheckError: the return value has unexpected extra key(s): "b'bytes'", "str"
```