### PR TITLE
Replaced the PEP 604 union transformer with a simpler one

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,7 +8,7 @@ This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-v
 - **BACKWARD INCOMPATIBLE** ``check_return_value`` now returns the value it was passed,
   making it possible to use it together with ``return`` on the same line
 - Added support for PEP 604 union types (``X | Y``) on all Python versions using a
-  Lark based parser (contributed by supersergiy)
+  Lark based parser (initial implementation contributed by supersergiy)
 - Added the possibility to have the import hook instrument all packages
 - Added the ``check_yield_type()`` function for type checking yields in generator
   functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ requires-python = ">= 3.7.4"
 dependencies = [
     "importlib_metadata >= 3.6; python_version < '3.10'",
     "typing_extensions >= 4.4.0; python_version < '3.11'",
-    "lark >= 1.1.5; python_version < '3.10'",
 ]
 dynamic = ["version"]
 

--- a/tests/test_union_transformer.py
+++ b/tests/test_union_transformer.py
@@ -1,29 +1,44 @@
-import pytest
+import typing
+from typing import Callable
 
-from typeguard._union_transformer import translate_type_hint
+import pytest
+from typing_extensions import Literal
+
+from typeguard._union_transformer import compile_type_hint, type_substitutions
+
+eval_globals = {"Callable": Callable, "Literal": Literal, "typing": typing}
+eval_globals.update(type_substitutions)
 
 
 @pytest.mark.parametrize(
     "inputval, expected",
     [
-        ["a | b", "Union[a, b]"],
-        ["a | b | c", "Union[a, b, c]"],
-        ["a | Union[b | c, d]", "Union[a, Union[Union[b, c], d]]"],
-        ["a | b | Callable[..., c]", "Union[a, b, Callable[..., c]]"],
-        ["a | b | Callable[[], c]", "Union[a, b, Callable[[], c]]"],
-        ["a | b | Callable[[], c | d]", "Union[a, b, Callable[[], Union[c, d]]]"],
-        ["a | b | Literal[1]", "Union[a, b, Literal[1]]"],
-        ["a | b | Literal[-1]", "Union[a, b, Literal[-1]]"],
-        ["a | b | Literal[-1]", "Union[a, b, Literal[-1]]"],
+        ["str | int", "Union[str, int]"],
+        ["str | int | bytes", "Union[str, int, bytes]"],
+        ["str | Union[int | bytes, set]", "Union[str, int, bytes, Set]"],
+        ["str | int | Callable[..., bytes]", "Union[str, int, Callable[..., bytes]]"],
+        ["str | int | Callable[[], bytes]", "Union[str, int, Callable[[], bytes]]"],
         [
-            'a | b | Literal["It\'s a string \'\\""]',
-            'Union[a, b, Literal["It\'s a string \'\\""]]',
+            "str | int | Callable[[], bytes | set]",
+            "Union[str, int, Callable[[], Union[bytes, Set]]]",
+        ],
+        ["str | int | Literal['foo']", "Union[str, int, Literal['foo']]"],
+        ["str | int | Literal[-1]", "Union[str, int, Literal[-1]]"],
+        ["str | int | Literal[-1]", "Union[str, int, Literal[-1]]"],
+        [
+            'str | int | Literal["It\'s a string \'\\""]',
+            "Union[str, int, Literal['It\\'s a string \\'\"']]",
         ],
         [
             "typing.Tuple | typing.List | Literal[-1]",
-            "Union[typing.Tuple, typing.List, Literal[-1]]",
+            "Union[Tuple, List, Literal[-1]]",
         ],
     ],
 )
-def test_union_transformer(inputval, expected):
-    assert translate_type_hint(inputval) == expected
+def test_union_transformer(inputval: str, expected: str) -> None:
+    code = compile_type_hint(inputval)
+    evaluated = eval(code, eval_globals)
+    evaluated_repr = repr(evaluated)
+    evaluated_repr = evaluated_repr.replace("typing.", "")
+    evaluated_repr = evaluated_repr.replace("typing_extensions.", "")
+    assert evaluated_repr == expected


### PR DESCRIPTION
This also makes it possible to use the built-in collection types as generic.