### PR TITLE
Fix TypedDict checker for odd types

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,10 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
+**UNRELEASED**
+
+- Fixed checking against mixed types when ``TypedDict`` is one of the types
+
 **3.0.2** (2023-03-22)
 
 - Improved warnings by ensuring that they target user code and not Typeguard internal

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,7 +5,8 @@ This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-v
 
 **UNRELEASED**
 
-- Fixed checking against mixed types when ``TypedDict`` is one of the types
+- Fixed checking non-dictionary objects against a ``TypedDict`` annotation
+  (PR by Tolker-KU)
 
 **3.0.2** (2023-03-22)
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -233,6 +233,9 @@ def check_mapping(
 def check_typed_dict(
     value: Any, origin_type: Any, args: tuple[Any, ...], memo: TypeCheckMemo
 ) -> None:
+    if not (isinstance(value, dict) or is_typeddict(value)):
+        raise TypeCheckError("is not a TypedDict")
+
     declared_keys = frozenset(origin_type.__annotations__)
     if hasattr(origin_type, "__required_keys__"):
         required_keys = origin_type.__required_keys__

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -233,8 +233,8 @@ def check_mapping(
 def check_typed_dict(
     value: Any, origin_type: Any, args: tuple[Any, ...], memo: TypeCheckMemo
 ) -> None:
-    if not (isinstance(value, dict) or is_typeddict(value)):
-        raise TypeCheckError("is not a TypedDict")
+    if not isinstance(value, dict):
+        raise TypeCheckError("is not a dict")
 
     declared_keys = frozenset(origin_type.__annotations__)
     if hasattr(origin_type, "__required_keys__"):

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -461,8 +461,8 @@ class TestTypedDict:
             pytest.param(
                 None,
                 True,
-                "is not a TypedDict",
-                id="not_iterable_type",
+                "is not a dict",
+                id="not_dict",
             ),
         ],
     )

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -458,6 +458,12 @@ class TestTypedDict:
                 r'dict has unexpected extra key\(s\): "foo"',
                 id="unknown_key",
             ),
+            pytest.param(
+                None,
+                True,
+                "is not a TypedDict",
+                id="not_iterable_type",
+            ),
         ],
     )
     def test_typed_dict(self, value, total: bool, error_re: Optional[str]):


### PR DESCRIPTION
The checker for TypedDict explodes if passed some odd type. This should fix this problem.