### PR TITLE
Call pytest indirectly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ minversion = 4.0
 
 [testenv]
 extras = test
-commands = pytest {posargs}
+commands = python -m pytest {posargs}
 
 [testenv:docs]
 extras = doc


### PR DESCRIPTION
For better interoperability with `tox-current-env`.