### PR TITLE
Add `pass` to removed blocks of code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .tox
 .coverage
+**/.coverage.*
 .cache
 .eggs/
 *.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .pydevproject
 .idea
 .tox
-.coverage
 .coverage*
 .cache
 .eggs/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .idea
 .tox
 .coverage
-**/.coverage.*
+.coverage*
 .cache
 .eggs/
 *.egg-info/

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -7,10 +7,14 @@ This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-v
 
 - Dropped Python 3.7 support
 
+- Fixed ``@typechecked`` optimization causing compilation of instrumented code to fail
+  when any block was left empty by the AST transformer (eg `if` or `try` / `except` blocks)
+  (`#352 <https://github.com/agronholm/typeguard/issues/352>`_)
+
 **4.1.2** (2023-08-18)
 
 - Fixed ``Any`` being removed from a subscript that still contains other elements
-  (`#373 <https://github.com/agronholm/typeguard/issues/373>`_
+  (`#373 <https://github.com/agronholm/typeguard/issues/373>`_)
 
 **4.1.1** (2023-08-16)
 
@@ -21,7 +25,7 @@ This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-v
 
 - Added support for passing a tuple as ``expected_type`` to ``check_type()``, making it
   more of a drop-in replacement for ``isinstance()``
-  (`#371 <https://github.com/agronholm/typeguard/issues/371>`_
+  (`#371 <https://github.com/agronholm/typeguard/issues/371>`_)
 - Fixed regression where ``Literal`` inside a ``Union`` had quotes stripped from its
   contents, thus typically causing ``NameError`` to be raised when run
   (`#372 <https://github.com/agronholm/typeguard/issues/372>`_)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,7 +6,6 @@ This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-v
 **UNRELEASED**
 
 - Dropped Python 3.7 support
-
 - Fixed ``@typechecked`` optimization causing compilation of instrumented code to fail
   when any block was left empty by the AST transformer (eg `if` or `try` / `except` blocks)
   (`#352 <https://github.com/agronholm/typeguard/issues/352>`_)

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -509,7 +509,7 @@ class TypeguardTransformer(NodeTransformer):
 
         # Add `pass` to list fields that were optimised away
         for field_name in non_empty_list_fields:
-            if not hasattr(node, field_name) or not getattr(node, field_name):
+            if not getattr(node, field_name, None):
                 setattr(node, field_name, [Pass()])
 
         return node

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -66,8 +66,6 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, cast, overload
 
-from typing_extensions import override
-
 generator_names = (
     "typing.Generator",
     "collections.abc.Generator",
@@ -368,7 +366,6 @@ class AnnotationTransformer(NodeTransformer):
 
         return new_node
 
-    @override
     def generic_visit(self, node: AST) -> AST:
         if isinstance(node, expr) and self._memo.name_matches(node, *literal_names):
             return node
@@ -502,7 +499,6 @@ class TypeguardTransformer(NodeTransformer):
         self.target_node: FunctionDef | AsyncFunctionDef | None = None
         self.target_lineno = target_lineno
 
-    @override
     def generic_visit(self, node: AST) -> AST:
         non_empty_list_fields = []
         for field_name, val in iter_fields(node):

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -65,6 +65,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, cast, overload
+
 from typing_extensions import override
 
 generator_names = (


### PR DESCRIPTION
Solves #352 more generally.

We saw this in exception handlers but I think that it can manifest itself on any construct that has an expected child block.

We could potentially even totally remove the statements in the test as they are no-op.