### PR TITLE
Only fill-in empty bodies

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,11 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
+**UNRELEASED**
+
+- Only fill-in empty `body` blocks that may have been left empty by a ``@typechecked`` optimization
+  (`#352 <https://github.com/agronholm/typeguard/issues/352>`_)
+
 **4.1.3** (2023-08-27)
 
 - Dropped Python 3.7 support

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,11 +3,6 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
-**UNRELEASED**
-
-- Only fill-in empty `body` blocks that may have been left empty by a ``@typechecked`` optimization
-  (`#352 <https://github.com/agronholm/typeguard/issues/352>`_)
-
 **4.1.3** (2023-08-27)
 
 - Dropped Python 3.7 support

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -55,7 +55,6 @@ from ast import (
     copy_location,
     expr,
     fix_missing_locations,
-    iter_fields,
     keyword,
     walk,
 )
@@ -500,17 +499,20 @@ class TypeguardTransformer(NodeTransformer):
         self.target_lineno = target_lineno
 
     def generic_visit(self, node: AST) -> AST:
-        non_empty_list_fields = []
-        for field_name, val in iter_fields(node):
-            if isinstance(val, list) and len(val) > 0:
-                non_empty_list_fields.append(field_name)
+        has_non_empty_body_initially = bool(getattr(node, "body", None))
+        initial_type = type(node)
 
         node = super().generic_visit(node)
 
-        # Add `pass` to list fields that were optimised away
-        for field_name in non_empty_list_fields:
-            if not getattr(node, field_name, None):
-                setattr(node, field_name, [Pass()])
+        if (
+            type(node) is initial_type
+            and has_non_empty_body_initially
+            and hasattr(node, "body")
+            and not node.body
+        ):
+            # If we have still the same node type after transformation
+            # but we've optimised it's body away, we add a `pass` statement.
+            node.body = [Pass()]
 
         return node
 


### PR DESCRIPTION
Rather than any empty list-valued AST field.

This is an improvement on https://github.com/agronholm/typeguard/pull/386 given https://github.com/python/cpython/issues/108521#issuecomment-1694597859