### PR TITLE
Handle missing branches in `BinOp`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,9 +3,9 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
-**unreleased**
+**UNRELEASED**
 
-- Fixed handling of `BinOp` nodes with missing branches in AnnotationTransformer
+- Fixed ``AttributeError`` where the transformer removed elements from a PEP 604 union
   (`#384 <https://github.com/agronholm/typeguard/issues/384>`_)
 
 **4.1.3** (2023-08-27)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -3,6 +3,11 @@ Version history
 
 This library adheres to `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
+**unreleased**
+
+- Fixed handling of `BinOp` nodes with missing branches in AnnotationTransformer
+  (`#384 <https://github.com/agronholm/typeguard/issues/384>`_)
+
 **4.1.3** (2023-08-27)
 
 - Dropped Python 3.7 support

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -380,9 +380,9 @@ class AnnotationTransformer(NodeTransformer):
             # If this happens, treat the BinOp as just the other branch.
             if not hasattr(node, "left") and not hasattr(node, "right"):
                 return None
-            if not hasattr(node, "left"):
+            elif not hasattr(node, "left"):
                 return node.right
-            if not hasattr(node, "right"):
+            elif not hasattr(node, "right"):
                 return node.left
 
             # Return Any if either side is Any

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -376,6 +376,16 @@ class AnnotationTransformer(NodeTransformer):
         self.generic_visit(node)
 
         if isinstance(node.op, BitOr):
+            # If either branch of the BinOp has been transformed to `None`
+            # then the `ast.generic_visit` will eliminate that branch completely.
+            # If this happens, treat the BinOp as just the other branch.
+            if not hasattr(node, "left") and not hasattr(node, "right"):
+                return None
+            if not hasattr(node, "left"):
+                return node.right
+            if not hasattr(node, "right"):
+                return node.left
+
             # Return Any if either side is Any
             if self._memo.name_matches(node.left, *anytype_names):
                 return node.left

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1570,6 +1570,37 @@ def test_dont_leave_empty_ast_container_nodes_2() -> None:
     )
 
 
+def test_union_annotation_with_or_operator() -> None:
+    node = parse(
+        dedent(
+            """
+            from __future__ import annotations
+
+            class A:
+                ...
+
+            def foo(A: A | None) -> None:
+                pass
+            """
+        )
+    )
+    TypeguardTransformer(["foo"]).visit(node)
+    assert (
+        unparse(node)
+        == dedent(
+            """
+            from __future__ import annotations
+
+            def foo(A: A | None) -> None:
+                from typeguard import TypeCheckMemo
+                from typeguard._functions import check_argument_types
+                memo = TypeCheckMemo(globals(), locals())
+                check_argument_types('foo', {'A': (A, None)}, memo)
+            """
+        ).strip()
+    )
+
+
 def test_dont_parse_annotated_2nd_arg() -> None:
     # Regression test for #352
     node = parse(


### PR DESCRIPTION
Fixes https://github.com/agronholm/typeguard/issues/384 .

The issue is due to the `left` or `right` attributes of `BinOp` in the case that the `AnnotationTransformer` evaluates any of them to be `None`.

The code that removes the attributes completely is:
https://github.com/python/cpython/blob/e407cea1938b80b1d469f148a4ea65587820e3eb/Lib/ast.py#L493-L498

This patch removes the crush but I think shows another bug where in the test I added, the argument `A` is expected to only have a value of `None`. NB that this is not just wrong but also inconsistent with what happens when using `Union` instead of `|`