### PR TITLE
Fixed generic aliases not passing checks against `type`

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,6 +11,9 @@ This library adheres to
   subscript (`#442 <https://github.com/agronholm/typeguard/issues/442>`_)
 - Fixed ``TypedDict`` from ``typing_extensions`` not being recognized as one
   (`#443 <https://github.com/agronholm/typeguard/issues/443>`_)
+- Fixed parametrized types (``dict[str, int]``, ``List[str]``, etc.) not passing checks
+  against ``type`` or ``Type``
+  (`#432 <https://github.com/agronholm/typeguard/issues/432>`_, PR by Yongxin Wang)
 
 **4.1.5** (2023-09-11)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,7 +11,7 @@ This library adheres to
   subscript (`#442 <https://github.com/agronholm/typeguard/issues/442>`_)
 - Fixed ``TypedDict`` from ``typing_extensions`` not being recognized as one
   (`#443 <https://github.com/agronholm/typeguard/issues/443>`_)
-- Fixed parametrized types (``dict[str, int]``, ``List[str]``, etc.) not passing checks
+- Fixed ``typing`` types (``dict[str, int]``, ``List[str]``, etc.) not passing checks
   against ``type`` or ``Type``
   (`#432 <https://github.com/agronholm/typeguard/issues/432>`_, PR by Yongxin Wang)
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -438,7 +438,8 @@ def check_class(
     memo: TypeCheckMemo,
 ) -> None:
     if not isclass(value) and not (
-        sys.version_info >= (3, 11) and isinstance(value, types.GenericAlias)
+        (sys.version_info >= (3, 11) and isinstance(value, types.GenericAlias)) or
+        isinstance(value, type(Type)) or isinstance(value, type(Type[Any]))
     ):
         raise TypeCheckError("is not a class")
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -437,7 +437,9 @@ def check_class(
     args: tuple[Any, ...],
     memo: TypeCheckMemo,
 ) -> None:
-    if not isclass(value) and not (sys.version_info >= (3, 11) and isinstance(value, types.GenericAlias)):
+    if not isclass(value) and not (
+        sys.version_info >= (3, 11) and isinstance(value, types.GenericAlias)
+    ):
         raise TypeCheckError("is not a class")
 
     if not args:

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -83,6 +83,9 @@ TypeCheckLookupCallback: TypeAlias = Callable[
 ]
 
 checker_lookup_functions: list[TypeCheckLookupCallback] = []
+generic_alias_types: tuple[type, ...] = (type(List), type(List[Any]))
+if sys.version_info >= (3, 9):
+    generic_alias_types += (types.GenericAlias,)
 
 
 # Sentinel
@@ -440,11 +443,7 @@ def check_class(
     args: tuple[Any, ...],
     memo: TypeCheckMemo,
 ) -> None:
-    if not isclass(value) and not (
-        (sys.version_info >= (3, 11) and isinstance(value, types.GenericAlias))
-        or isinstance(value, type(Type))
-        or isinstance(value, type(Type[Any]))
-    ):
+    if not isclass(value) and not isinstance(value, generic_alias_types):
         raise TypeCheckError("is not a class")
 
     if not args:
@@ -479,7 +478,7 @@ def check_class(
             raise TypeCheckError(
                 f"did not match any element in the union:\n{formatted_errors}"
             )
-    elif not issubclass(value, expected_class):
+    elif not issubclass(value, expected_class):  # type: ignore[arg-type]
         raise TypeCheckError(f"is not a subclass of {qualified_name(expected_class)}")
 
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -438,8 +438,9 @@ def check_class(
     memo: TypeCheckMemo,
 ) -> None:
     if not isclass(value) and not (
-        (sys.version_info >= (3, 11) and isinstance(value, types.GenericAlias)) or
-        isinstance(value, type(Type)) or isinstance(value, type(Type[Any]))
+        (sys.version_info >= (3, 11) and isinstance(value, types.GenericAlias))
+        or isinstance(value, type(Type))
+        or isinstance(value, type(Type[Any]))
     ):
         raise TypeCheckError("is not a class")
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -437,7 +437,7 @@ def check_class(
     args: tuple[Any, ...],
     memo: TypeCheckMemo,
 ) -> None:
-    if not isclass(value):
+    if not isclass(value) and not (sys.version_info >= (3, 11) and isinstance(value, types.GenericAlias)):
         raise TypeCheckError("is not a class")
 
     if not args:

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -889,6 +889,10 @@ class TestType:
     def test_union_typevar(self):
         T = TypeVar("T", bound=Parent)
         check_type(Child, Type[T])
+    
+    def test_generic_aliase(self):
+        if sys.version_info >= (3, 9):
+            check_type(dict[str, str], type)
 
 
 class TestIO:

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -889,7 +889,7 @@ class TestType:
     def test_union_typevar(self):
         T = TypeVar("T", bound=Parent)
         check_type(Child, Type[T])
-    
+
     def test_generic_aliase(self):
         if sys.version_info >= (3, 9):
             check_type(dict[str, str], type)

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -893,6 +893,8 @@ class TestType:
     def test_generic_aliase(self):
         if sys.version_info >= (3, 9):
             check_type(dict[str, str], type)
+        check_type(Dict, Type[Any])
+        check_type(Dict[str, str], Type[Any])
 
 
 class TestIO:

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -891,11 +891,13 @@ class TestType:
         T = TypeVar("T", bound=Parent)
         check_type(Child, Type[T])
 
-    def test_generic_aliase(self):
+    @pytest.mark.parametrize("check_against", [type, Type[Any]])
+    def test_generic_aliase(self, check_against):
         if sys.version_info >= (3, 9):
-            check_type(dict[str, str], type)
-        check_type(Dict, Type[Any])
-        check_type(Dict[str, str], Type[Any])
+            check_type(dict[str, str], check_against)
+
+        check_type(Dict, check_against)
+        check_type(Dict[str, str], check_against)
 
 
 class TestIO:


### PR DESCRIPTION
fixes #432

`is_class(dict[str,str], type)` returns `False` after python 3.11. Use `isinstance(dict[str, str], types.GenericAlias)` to check in this situation.