### PR TITLE
Support Python 3.13

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,8 @@ This library adheres to
 
 **UNRELEASED**
 
+- Fixed some compatibility problems when running on Python 3.13
+  (`#460 <https://github.com/agronholm/typeguard/issues/460>`_)
 - Fixed test suite incompatibility with pytest 8.2
   (`#461 <https://github.com/agronholm/typeguard/issues/461>`_)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">= 3.8"
 dependencies = [
     "importlib_metadata >= 3.6; python_version < '3.10'",
-    "typing_extensions >= 4.10.0; python_version < '3.13'",
+    "typing_extensions >= 4.10.0",
 ]
 dynamic = ["version"]
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -43,10 +43,11 @@ from ._exceptions import TypeCheckError, TypeHintWarning
 from ._memo import TypeCheckMemo
 from ._utils import evaluate_forwardref, get_stacklevel, get_type_name, qualified_name
 
-if sys.version_info >= (3, 14):
-    from typing import is_typeddict
-else:
-    from typing_extensions import is_typeddict
+# Must use this because typing.is_typeddict does not recognize
+# TypedDict from typing_extensions, and as of version 4.12.0
+# typing_extensions.TypedDict is different from typing.TypedDict
+# on all versions.
+from typing_extensions import is_typeddict
 
 if sys.version_info >= (3, 11):
     from typing import (

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -38,16 +38,16 @@ try:
 except ImportError:
     typing_extensions = None  # type: ignore[assignment]
 
-from ._config import ForwardRefPolicy
-from ._exceptions import TypeCheckError, TypeHintWarning
-from ._memo import TypeCheckMemo
-from ._utils import evaluate_forwardref, get_stacklevel, get_type_name, qualified_name
-
 # Must use this because typing.is_typeddict does not recognize
 # TypedDict from typing_extensions, and as of version 4.12.0
 # typing_extensions.TypedDict is different from typing.TypedDict
 # on all versions.
 from typing_extensions import is_typeddict
+
+from ._config import ForwardRefPolicy
+from ._exceptions import TypeCheckError, TypeHintWarning
+from ._memo import TypeCheckMemo
+from ._utils import evaluate_forwardref, get_stacklevel, get_type_name, qualified_name
 
 if sys.version_info >= (3, 11):
     from typing import (

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -43,7 +43,7 @@ from ._exceptions import TypeCheckError, TypeHintWarning
 from ._memo import TypeCheckMemo
 from ._utils import evaluate_forwardref, get_stacklevel, get_type_name, qualified_name
 
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 14):
     from typing import is_typeddict
 else:
     from typing_extensions import is_typeddict

--- a/src/typeguard/_utils.py
+++ b/src/typeguard/_utils.py
@@ -15,7 +15,9 @@ if sys.version_info >= (3, 10):
     from typing import get_args, get_origin
 
     def evaluate_forwardref(forwardref: ForwardRef, memo: TypeCheckMemo) -> Any:
-        return forwardref._evaluate(memo.globals, memo.locals, recursive_guard=frozenset())
+        return forwardref._evaluate(
+            memo.globals, memo.locals, recursive_guard=frozenset()
+        )
 
 else:
     from typing_extensions import get_args, get_origin

--- a/src/typeguard/_utils.py
+++ b/src/typeguard/_utils.py
@@ -11,7 +11,15 @@ from weakref import WeakValueDictionary
 if TYPE_CHECKING:
     from ._memo import TypeCheckMemo
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 13):
+    from typing import get_args, get_origin
+
+    def evaluate_forwardref(forwardref: ForwardRef, memo: TypeCheckMemo) -> Any:
+        return forwardref._evaluate(
+            memo.globals, memo.locals, type_params=(), recursive_guard=frozenset()
+        )
+
+elif sys.version_info >= (3, 10):
     from typing import get_args, get_origin
 
     def evaluate_forwardref(forwardref: ForwardRef, memo: TypeCheckMemo) -> Any:

--- a/src/typeguard/_utils.py
+++ b/src/typeguard/_utils.py
@@ -15,7 +15,7 @@ if sys.version_info >= (3, 10):
     from typing import get_args, get_origin
 
     def evaluate_forwardref(forwardref: ForwardRef, memo: TypeCheckMemo) -> Any:
-        return forwardref._evaluate(memo.globals, memo.locals, frozenset())
+        return forwardref._evaluate(memo.globals, memo.locals, recursive_guard=frozenset())
 
 else:
     from typing_extensions import get_args, get_origin

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -43,6 +43,7 @@ from typeguard import (
     check_type_internal,
     suppress_type_checks,
 )
+from typeguard._checkers import is_typeddict
 from typeguard._utils import qualified_name
 
 from . import (
@@ -529,6 +530,14 @@ class TestTypedDict:
             TypeCheckError, match=r"value of key 'y' of dict is not an instance of int"
         ):
             check_type({"x": 1, "y": "foo"}, DummyDict)
+
+    def test_is_typeddict(self, typing_provider):
+        # Ensure both typing.TypedDict and typing_extensions.TypedDict are recognized
+        class DummyDict(typing_provider.TypedDict):
+            x: int
+
+        assert is_typeddict(DummyDict)
+        assert not is_typeddict(dict)
 
 
 class TestList:


### PR DESCRIPTION
- typing.is_typeddict() does not recognize typing_extensions.TypedDict
- ForwardRef._evaluate gained another parameter
