### PR TITLE
Fix `pytest_ignore_collect` not to block default pytest code

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -22,6 +22,9 @@ This library adheres to
 - Fixed checks against annotations wrapped in ``NotRequired`` not being run unless the
   ``NotRequired`` is a forward reference
   (`#454 <https://github.com/agronholm/typeguard/issues/454>`_)
+- Fixed the ``pytest_ignore_collect`` hook in the pytest plugin blocking default pytest
+  collection ignoring behavior by returning ``None`` instead of ``False``
+  (PR by @mgorny)
 
 **4.4.0** (2024-10-27)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,14 +13,16 @@ version_re = re.compile(r"_py(\d)(\d)\.py$")
 pytest_plugins = ["pytester"]
 
 
-def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool:
+def pytest_ignore_collect(
+    collection_path: Path, config: pytest.Config
+) -> typing.Optional[bool]:
     match = version_re.search(collection_path.name)
     if match:
         version = tuple(int(x) for x in match.groups())
         if sys.version_info < version:
             return True
 
-    return False
+    return None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Changes

Fix `pytest_ignore_collect` hook implementation to return `None` rather than `False` when the path ought not to be ignored.  This is necessary to enable the default pytest implementation of `pytest_ignore_collect()` to be used.  Otherwise, the default rules are never applied and e.g. `--ignore` does not work.

I've also reported https://github.com/pytest-dev/pytest/issues/12383 about the misleading documentation.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the pytest plugin (#999
<https://github.com/agronholm/typeguard/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
