### PR TITLE
fix: lower bound typing-extensions >= 4.6

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,6 +4,11 @@ Version history
 This library adheres to
 `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
+**UNRELEASED**
+
+- Fixed lower bound typing-extensions >= 4.6
+  (`#472 <https://github.com/agronholm/typeguard/issues/472>`_; PR by @ymerkli)`
+
 **4.3.0** (2024-05-27)
 
 - Added support for checking against static protocols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
     "setuptools >= 64",
-    "setuptools_scm[toml] >= 6.4"
+    "setuptools_scm[toml] >= 6.4",
+    "typing-extensions >= 4.6"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes https://github.com/agronholm/typeguard/issues/472

typeguard uses `typing_extensions.Buffer`, which was only added to `typing_extenions>=4.6.0`, [see here](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-460-may-22-2023).

This PR adds `typing_extenions>=4.6.0` as a requirement.


## Checklist

- [x] If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.
- [x] Updating the changelog
