### PR TITLE
Support classmethod w/ pos-only arguments

### DIFF
--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -863,8 +863,9 @@ class TypeguardTransformer(NodeTransformer):
                             isinstance(decorator, Name)
                             and decorator.id == "classmethod"
                         ):
+                            arglist = node.args.args or node.args.posonlyargs
                             memo_kwargs["self_type"] = Name(
-                                id=node.args.args[0].arg, ctx=Load()
+                                id=arglist[0].arg, ctx=Load()
                             )
                             break
                     else:


### PR DESCRIPTION
## Changes

While upgrading `typeguard` internally at our company, I noticed it does not handle `classmethod`s with positional-only arguments. While I have no idea why someone would need that, I could not find online why this should not be done. This PR fixes this issue.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

Will update changelog once we agree on the approach here.
