### PR TITLE
Fixed annotation for `typeguard_ignore()` to match one for `typing.no_type_check()`

### DIFF
--- a/src/typeguard/_decorators.py
+++ b/src/typeguard/_decorators.py
@@ -16,19 +16,17 @@ from ._functions import TypeCheckFailCallback
 from ._transformer import TypeguardTransformer
 from ._utils import Unset, function_name, get_stacklevel, is_method_of, unset
 
+T_CallableOrType = TypeVar("T_CallableOrType", bound=Callable[..., Any])
+
 if TYPE_CHECKING:
     from typeshed.stdlib.types import _Cell
 
-    _F = TypeVar("_F")
-
-    def typeguard_ignore(f: _F) -> _F:
+    def typeguard_ignore(f: T_CallableOrType) -> T_CallableOrType:
         """This decorator is a noop during static type-checking."""
         return f
 
 else:
     from typing import no_type_check as typeguard_ignore  # noqa: F401
-
-T_CallableOrType = TypeVar("T_CallableOrType", bound=Callable[..., Any])
 
 
 def make_cell(value: object) -> _Cell:


### PR DESCRIPTION
Trivial fix to make sure `typeguard_ignore()` has the same type signature in both `TYPE_CHECKING` and runtime branches.
