### PR TITLE
Fix tests to work on Windows.

### DIFF
--- a/tests/test_importhook.py
+++ b/tests/test_importhook.py
@@ -64,5 +64,6 @@ def test_debug_instrumentation(monkeypatch, capsys):
     monkeypatch.setattr("typeguard.config.debug_instrumentation", True)
     import_dummymodule()
     out, err = capsys.readouterr()
-    assert f"Source code of '{dummy_module_path}' after instrumentation:" in err
+    path_str = str(dummy_module_path)
+    assert f"Source code of {path_str!r} after instrumentation:" in err
     assert "class DummyClass" in err

--- a/tests/test_typechecked.py
+++ b/tests/test_typechecked.py
@@ -619,9 +619,8 @@ def test_typechecked_disabled_in_optimized_mode(
     )
     assert process.returncode == expected_return_code
     if process.returncode == 1:
-        assert process.stderr.endswith(
-            b'typeguard.TypeCheckError: argument "x" (str) is not an instance of '
-            b"int\n"
+        assert process.stderr.strip().endswith(
+            b'typeguard.TypeCheckError: argument "x" (str) is not an instance of int'
         )
 
 


### PR DESCRIPTION
## Changes

A few tests fail on a clean checkout on Windows due to formatting differences (CRLF newlines and \ in filenames). These should now pass on both Windows and Unix/Linux platforms.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [n/a] You've added tests (in `tests/`) added which would fail without your patch
  (these are the tests that are already there!)
- [n/a] You've updated the documentation (in `docs/`, in case of behavior changes or new features)
  (no behavior changes or new features)
- [n/a] You've added a new changelog entry (in `docs/versionhistory.rst`).
  (trivial)