### PR TITLE
Add tests for empty protocols on built-in objects.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -57,3 +57,12 @@ class RuntimeProtocol(Protocol):
     member: int
 
     def meth(self, x: str) -> None: ...
+
+
+class EmptyStaticProtocol(Protocol):
+    pass
+
+
+@runtime_checkable
+class EmptyRuntimeProtocol(Protocol):
+    pass

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -52,6 +52,8 @@ from typeguard._utils import qualified_name
 from . import (
     Child,
     Employee,
+    EmptyRuntimeProtocol,
+    EmptyStaticProtocol,
     JSONType,
     Parent,
     RuntimeProtocol,
@@ -1191,6 +1193,22 @@ class TestProtocol:
             pytest.raises(TypeCheckError, check_type, subject, annotation).match(
                 pattern
             )
+
+
+@pytest.mark.parametrize(
+    "instantiate, annotation",
+    [
+        pytest.param(True, EmptyRuntimeProtocol, id="instance_runtime"),
+        pytest.param(False, Type[EmptyRuntimeProtocol], id="class_runtime"),
+        pytest.param(True, EmptyStaticProtocol, id="instance_static"),
+        pytest.param(False, Type[EmptyStaticProtocol], id="class_static"),
+    ],
+)
+@pytest.mark.parametrize("instance_type", [object, str, Parent])
+class TestEmptyProtocol:
+    def test_empty_protocol(self, instantiate, annotation, instance_type):
+        subject = instance_type() if instantiate else instance_type
+        check_type(subject, annotation)
 
 
 class TestRecursiveType:


### PR DESCRIPTION
One of the symptoms of the earlier problem was that you could not check protocols against built-in types at all. This adds a test specifically for that situation to prevent a regression.


## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [n/a] You've added tests (in `tests/`) added which would fail without your patch
  Regression test for change #490.
- [n/a] You've updated the documentation (in `docs/`, in case of behavior changes or new features)
- [n/a] You've added a new changelog entry (in `docs/versionhistory.rst`).