### PR TITLE
Fixes for Python 3.14 and PEP 649

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", pypy-3.10]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", pypy-3.10]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,8 @@ This library adheres to
 
 - Fixed basic support for intersection protocols
   (`#490 <https://github.com/agronholm/typeguard/pull/490>`_; PR by @antonagestam)
+- Fix display of module name for forward references
+  (`#492 <https://github.com/agronholm/typeguard/pull/492>`_; PR by @JelleZijlstra)
 
 **4.3.0** (2024-05-27)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 requires-python = ">= 3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ strict = true
 pretty = true
 
 [tool.tox]
-env_list = ["py39", "py310", "py311", "py312", "py313"]
+env_list = ["py39", "py310", "py311", "py312", "py313", "py314"]
 skip_missing_interpreters = true
 
 [tool.tox.env_run_base]

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -533,7 +533,7 @@ def check_typevar(
 ) -> None:
     if origin_type.__bound__ is not None:
         annotation = (
-            Type[origin_type.__bound__] if subclass_check else origin_type.__bound__
+            type[origin_type.__bound__] if subclass_check else origin_type.__bound__
         )
         check_type_internal(value, annotation, memo)
     elif origin_type.__constraints__:

--- a/src/typeguard/_decorators.py
+++ b/src/typeguard/_decorators.py
@@ -117,7 +117,10 @@ def instrument(f: T_CallableOrType) -> FunctionType | str:
     new_function.__module__ = f.__module__
     new_function.__name__ = f.__name__
     new_function.__qualname__ = f.__qualname__
-    new_function.__annotations__ = f.__annotations__
+    if sys.version_info >= (3, 14):
+        new_function.__annotate__ = f.__annotate__
+    else:
+        new_function.__annotations__ = f.__annotations__
     new_function.__doc__ = f.__doc__
     new_function.__defaults__ = f.__defaults__
     new_function.__kwdefaults__ = f.__kwdefaults__

--- a/src/typeguard/_utils.py
+++ b/src/typeguard/_utils.py
@@ -11,7 +11,15 @@ from weakref import WeakValueDictionary
 if TYPE_CHECKING:
     from ._memo import TypeCheckMemo
 
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 14):
+    from typing import get_args, get_origin
+
+    def evaluate_forwardref(forwardref: ForwardRef, memo: TypeCheckMemo) -> Any:
+        return forwardref.evaluate(
+            globals=memo.globals, locals=memo.locals, type_params=()
+        )
+
+elif sys.version_info >= (3, 13):
     from typing import get_args, get_origin
 
     def evaluate_forwardref(forwardref: ForwardRef, memo: TypeCheckMemo) -> Any:
@@ -87,7 +95,11 @@ def get_type_name(type_: Any) -> str:
 
         name += f"[{formatted_args}]"
 
-    module = getattr(type_, "__module__", None)
+    # For ForwardRefs, use the module stored on the object if available
+    if hasattr(type_, "__forward_module__"):
+        module = type_.__forward_module__
+    else:
+        module = getattr(type_, "__module__", None)
     if module and module not in (None, "typing", "typing_extensions", "builtins"):
         name = module + "." + name
 

--- a/tests/deferredannos.py
+++ b/tests/deferredannos.py
@@ -2,7 +2,7 @@ from typeguard import typechecked
 
 
 @typechecked
-def uses_forwardref(x: NotYetDefined) -> NotYetDefined:
+def uses_forwardref(x: NotYetDefined) -> NotYetDefined:  # noqa: F821
     return x
 
 

--- a/tests/deferredannos.py
+++ b/tests/deferredannos.py
@@ -1,0 +1,10 @@
+from typeguard import typechecked
+
+
+@typechecked
+def uses_forwardref(x: NotYetDefined) -> NotYetDefined:
+    return x
+
+
+class NotYetDefined:
+    pass


### PR DESCRIPTION
I ran the typeguard test suite on the current CPython main branch to
look for possible breakage from PEP 649 and 749, which makes large
changes to how annotations work.

I found three problems:

- DeprecationWarnings from uses of ForwardRef._evaluate, which we're
  deprecating. Made a change to use the new public API for ForwardRef.evaluate
  instead.
- A test failure that showed "annotationlib" as the module name for a forward
  ref. I made it so that it doesn't use __module__ for ForwardRef objects.
- One remaining test failure that I haven't tracked down:
  tests/test_instrumentation.py::test_typevar_forwardref[importhook]
  It's apparently due to caching (it doesn't fail if I run only that one test),
  but I haven't tracked down the exact cause.

I also added some new tests relying on 3.14-only behavior (unquoted annotations containing forward references). Those mostly worked fine, but I had to make another tweak to how functions are wrapped.

Since the APIs in Python 3.14 may still change, I'll make this a draft
PR for now.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
