### PR TITLE
Fix ref cycles

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -8,6 +8,7 @@ This library adheres to
 
 - Fixed basic support for intersection protocols
   (`#490 <https://github.com/agronholm/typeguard/pull/490>`_; PR by @antonagestam)
+- Avoid creating reference cycles when type checking uniontypes and classes
 
 **4.3.0** (2024-05-27)
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -445,6 +445,7 @@ def check_uniontype(
         )
     finally:
         del errors  # avoid creating ref cycle
+
     raise TypeCheckError(f"did not match any element in the union:\n{formatted_errors}")
 
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -479,22 +479,22 @@ def check_class(
     elif get_origin(expected_class) is Union:
         errors: dict[str, TypeCheckError] = {}
         try:
-          for arg in get_args(expected_class):
-              if arg is Any:
-                  return
+            for arg in get_args(expected_class):
+                if arg is Any:
+                    return
 
-              try:
-                  check_class(value, type, (arg,), memo)
-                  return
-              except TypeCheckError as exc:
-                  errors[get_type_name(arg)] = exc
-          else:
-              formatted_errors = indent(
-                  "\n".join(f"{key}: {error}" for key, error in errors.items()), "  "
-              )
-              raise TypeCheckError(
-                  f"did not match any element in the union:\n{formatted_errors}"
-              )
+                try:
+                    check_class(value, type, (arg,), memo)
+                    return
+                except TypeCheckError as exc:
+                    errors[get_type_name(arg)] = exc
+            else:
+                formatted_errors = indent(
+                    "\n".join(f"{key}: {error}" for key, error in errors.items()), "  "
+                )
+                raise TypeCheckError(
+                    f"did not match any element in the union:\n{formatted_errors}"
+                )
         finally:
             del errors  # avoid creating ref cycle
     elif not issubclass(value, expected_class):  # type: ignore[arg-type]

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -437,16 +437,19 @@ def check_uniontype(
     memo: TypeCheckMemo,
 ) -> None:
     errors: dict[str, TypeCheckError] = {}
-    for type_ in args:
-        try:
-            check_type_internal(value, type_, memo)
-            return
-        except TypeCheckError as exc:
-            errors[get_type_name(type_)] = exc
+    try:
+        for type_ in args:
+            try:
+                check_type_internal(value, type_, memo)
+                return
+            except TypeCheckError as exc:
+                errors[get_type_name(type_)] = exc
 
-    formatted_errors = indent(
-        "\n".join(f"{key}: {error}" for key, error in errors.items()), "  "
-    )
+        formatted_errors = indent(
+            "\n".join(f"{key}: {error}" for key, error in errors.items()), "  "
+        )
+    finally:
+        del errors  # avoid creating ref cycle
     raise TypeCheckError(f"did not match any element in the union:\n{formatted_errors}")
 
 
@@ -475,22 +478,25 @@ def check_class(
         check_typevar(value, expected_class, (), memo, subclass_check=True)
     elif get_origin(expected_class) is Union:
         errors: dict[str, TypeCheckError] = {}
-        for arg in get_args(expected_class):
-            if arg is Any:
-                return
+        try:
+          for arg in get_args(expected_class):
+              if arg is Any:
+                  return
 
-            try:
-                check_class(value, type, (arg,), memo)
-                return
-            except TypeCheckError as exc:
-                errors[get_type_name(arg)] = exc
-        else:
-            formatted_errors = indent(
-                "\n".join(f"{key}: {error}" for key, error in errors.items()), "  "
-            )
-            raise TypeCheckError(
-                f"did not match any element in the union:\n{formatted_errors}"
-            )
+              try:
+                  check_class(value, type, (arg,), memo)
+                  return
+              except TypeCheckError as exc:
+                  errors[get_type_name(arg)] = exc
+          else:
+              formatted_errors = indent(
+                  "\n".join(f"{key}: {error}" for key, error in errors.items()), "  "
+              )
+              raise TypeCheckError(
+                  f"did not match any element in the union:\n{formatted_errors}"
+              )
+        finally:
+            del errors  # avoid creating ref cycle
     elif not issubclass(value, expected_class):  # type: ignore[arg-type]
         raise TypeCheckError(f"is not a subclass of {qualified_name(expected_class)}")
 

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -857,10 +857,8 @@ class TestUnion:
     @pytest.mark.skipif(
         sys.implementation.name != "cpython",
         reason="Test relies on CPython's reference counting behavior",
-        )
-    @pytest.mark.skipif(
-        sys.version_info < (3, 10), reason="UnionType requires 3.10"
     )
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="UnionType requires 3.10")
     def test_uniontype_reference_leak(self):
         class Leak:
             def __del__(self):
@@ -891,6 +889,7 @@ class TestUnion:
         leaked = True
         inner3()
         assert not leaked
+
 
 class TestTypevar:
     def test_bound(self):

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -824,8 +824,6 @@ class TestUnion:
         reason="Test relies on CPython's reference counting behavior",
     )
     def test_union_reference_leak(self):
-        leaked = True
-
         class Leak:
             def __del__(self):
                 nonlocal leaked
@@ -835,19 +833,64 @@ class TestUnion:
             leak = Leak()  # noqa: F841
             check_type(b"asdf", Union[str, bytes])
 
+        leaked = True
         inner1()
         assert not leaked
 
-        leaked = True
-
         def inner2():
+            leak = Leak()  # noqa: F841
+            check_type(b"asdf", Union[bytes, str])
+
+        leaked = True
+        inner2()
+        assert not leaked
+
+        def inner3():
             leak = Leak()  # noqa: F841
             with pytest.raises(TypeCheckError, match="any element in the union:"):
                 check_type(1, Union[str, bytes])
 
+        leaked = True
+        inner3()
+        assert not leaked
+
+    @pytest.mark.skipif(
+        sys.implementation.name != "cpython",
+        reason="Test relies on CPython's reference counting behavior",
+        )
+    @pytest.mark.skipif(
+        sys.version_info < (3, 10), reason="UnionType requires 3.10"
+    )
+    def test_uniontype_reference_leak(self):
+        class Leak:
+            def __del__(self):
+                nonlocal leaked
+                leaked = False
+
+        def inner1():
+            leak = Leak()  # noqa: F841
+            check_type(b"asdf", str | bytes)
+
+        leaked = True
+        inner1()
+        assert not leaked
+
+        def inner2():
+            leak = Leak()  # noqa: F841
+            check_type(b"asdf", bytes | str)
+
+        leaked = True
         inner2()
         assert not leaked
 
+        def inner3():
+            leak = Leak()  # noqa: F841
+            with pytest.raises(TypeCheckError, match="any element in the union:"):
+                check_type(1, Union[str, bytes])
+
+        leaked = True
+        inner3()
+        assert not leaked
 
 class TestTypevar:
     def test_bound(self):


### PR DESCRIPTION
This change is essentially the same fix as in https://github.com/agronholm/typeguard/pull/408,
applied in two additional functions that use the same pattern.