### PR TITLE
Added proper Protocol method signature checking

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -65,13 +65,8 @@ As of version 4.3.0, Typeguard can check instances and classes against Protocols
 regardless of whether they were annotated with
 :func:`@runtime_checkable <typing.runtime_checkable>`.
 
-There are several limitations on the checks performed, however:
-
-* For non-callable members, only presence is checked for; no type compatibility checks
-  are performed
-* For methods, only the number of positional arguments are checked against, so any added
-  keyword-only arguments without defaults don't currently trip the checker
-* Likewise, argument types are not checked for compatibility
+The only current limitation is that argument annotations are not checked for
+compatibility, however this should be covered by static type checkers pretty well.
 
 Special considerations for ``if TYPE_CHECKING:``
 ------------------------------------------------

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -10,6 +10,8 @@ This library adheres to
   (`#465 <https://github.com/agronholm/typeguard/pull/465>`_)
 - Fixed basic support for intersection protocols
   (`#490 <https://github.com/agronholm/typeguard/pull/490>`_; PR by @antonagestam)
+- Fixed protocol checks running against the class of an instance and not the instance
+  itself (this produced wrong results for non-method member checks)
 
 **4.3.0** (2024-05-27)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,8 @@ This library adheres to
 
 **UNRELEASED**
 
+- Added proper checking for method signatures in protocol checks
+  (`#465 <https://github.com/agronholm/typeguard/pull/465>`_)
 - Fixed basic support for intersection protocols
   (`#490 <https://github.com/agronholm/typeguard/pull/490>`_; PR by @antonagestam)
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -33,7 +33,6 @@ from typing import (
     Union,
 )
 from unittest.mock import Mock
-from weakref import WeakKeyDictionary
 
 import typing_extensions
 
@@ -86,10 +85,6 @@ checker_lookup_functions: list[TypeCheckLookupCallback] = []
 generic_alias_types: tuple[type, ...] = (type(List), type(List[Any]))
 if sys.version_info >= (3, 9):
     generic_alias_types += (types.GenericAlias,)
-
-protocol_check_cache: WeakKeyDictionary[
-    type[Any], dict[type[Any], tuple[Any, ...] | None]
-] = WeakKeyDictionary()
 
 # Sentinel
 _missing = object()
@@ -644,6 +639,33 @@ def check_signature_compatible(
 ) -> None:
     subject_sig = inspect.signature(subject_callable)
     protocol_sig = inspect.signature(getattr(protocol, attrname))
+    protocol_type: typing.Literal["instance", "class", "static"] = "instance"
+    subject_type: typing.Literal["instance", "class", "static"] = "instance"
+
+    # Check if the protocol-side method is a class method or static method
+    if attrname in protocol.__dict__:
+        descriptor = protocol.__dict__[attrname]
+        if isinstance(descriptor, staticmethod):
+            protocol_type = "static"
+        elif isinstance(descriptor, classmethod):
+            protocol_type = "class"
+
+    # Check if the subject-side method is a class method or static method
+    if inspect.ismethod(subject_callable) and inspect.isclass(
+        subject_callable.__self__
+    ):
+        subject_type = "class"
+    elif not hasattr(subject_callable, "__self__"):
+        subject_type = "static"
+
+    if protocol_type == "instance" and subject_type != "instance":
+        raise TypeCheckError(
+            f"should be an instance method but it's a {subject_type} method"
+        )
+    elif protocol_type != "instance" and subject_type == "instance":
+        raise TypeCheckError(
+            f"should be a {protocol_type} method but it's an instance method"
+        )
 
     expected_varargs = any(
         param
@@ -687,12 +709,9 @@ def check_signature_compatible(
             in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
         ]
 
-        # Remove the "self" parameter from methods
-        if inspect.ismethod(subject_callable) or inspect.ismethoddescriptor(
-            subject_callable
-        ):
+        # Remove the "self" parameter from the protocol arguments to match
+        if protocol_type == "instance":
             protocol_args.pop(0)
-            subject_args.pop(0)
 
         for protocol_arg, subject_arg in zip_longest(protocol_args, subject_args):
             if protocol_arg is None:
@@ -763,65 +782,48 @@ def check_protocol(
     args: tuple[Any, ...],
     memo: TypeCheckMemo,
 ) -> None:
-    subject: type[Any] = value if isclass(value) else type(value)
-
-    if subject in protocol_check_cache:
-        result_map = protocol_check_cache[subject]
-        if origin_type in result_map:
-            if exc_args := result_map[origin_type]:
-                raise TypeCheckError(*exc_args)
-            else:
-                return
-
     origin_annotations = typing.get_type_hints(origin_type)
-    result_map = protocol_check_cache.setdefault(subject, {})
-    try:
-        for attrname in sorted(typing_extensions.get_protocol_members(origin_type)):
-            if (annotation := origin_annotations.get(attrname)) is not None:
-                try:
-                    subject_member = getattr(subject, attrname)
-                except AttributeError:
-                    raise TypeCheckError(
-                        f"is not compatible with the {origin_type.__qualname__} "
-                        f"protocol because it has no attribute named {attrname!r}"
-                    ) from None
+    for attrname in sorted(typing_extensions.get_protocol_members(origin_type)):
+        if (annotation := origin_annotations.get(attrname)) is not None:
+            try:
+                subject_member = getattr(value, attrname)
+            except AttributeError:
+                raise TypeCheckError(
+                    f"is not compatible with the {origin_type.__qualname__} "
+                    f"protocol because it has no attribute named {attrname!r}"
+                ) from None
 
-                try:
-                    check_type_internal(subject_member, annotation, memo)
-                except TypeCheckError as exc:
-                    raise TypeCheckError(
-                        f"is not compatible with the {origin_type.__qualname__} "
-                        f"protocol because its {attrname!r} attribute {exc}"
-                    ) from None
-            elif callable(getattr(origin_type, attrname)):
-                try:
-                    subject_member = getattr(subject, attrname)
-                except AttributeError:
-                    raise TypeCheckError(
-                        f"is not compatible with the {origin_type.__qualname__} "
-                        f"protocol because it has no method named {attrname!r}"
-                    ) from None
+            try:
+                check_type_internal(subject_member, annotation, memo)
+            except TypeCheckError as exc:
+                raise TypeCheckError(
+                    f"is not compatible with the {origin_type.__qualname__} "
+                    f"protocol because its {attrname!r} attribute {exc}"
+                ) from None
+        elif callable(getattr(origin_type, attrname)):
+            try:
+                subject_member = getattr(value, attrname)
+            except AttributeError:
+                raise TypeCheckError(
+                    f"is not compatible with the {origin_type.__qualname__} "
+                    f"protocol because it has no method named {attrname!r}"
+                ) from None
 
-                if not callable(subject_member):
-                    raise TypeCheckError(
-                        f"is not compatible with the {origin_type.__qualname__} "
-                        f"protocol because its {attrname!r} attribute is not a callable"
-                    )
+            if not callable(subject_member):
+                raise TypeCheckError(
+                    f"is not compatible with the {origin_type.__qualname__} "
+                    f"protocol because its {attrname!r} attribute is not a callable"
+                )
 
-                # TODO: implement assignability checks for parameter and return value
-                #  annotations
-                try:
-                    check_signature_compatible(subject_member, origin_type, attrname)
-                except TypeCheckError as exc:
-                    raise TypeCheckError(
-                        f"is not compatible with the {origin_type.__qualname__} "
-                        f"protocol because its {attrname!r} method {exc}"
-                    ) from None
-    except TypeCheckError as exc:
-        result_map[origin_type] = exc.args
-        raise
-    else:
-        result_map[origin_type] = None
+            # TODO: implement assignability checks for parameter and return value
+            #  annotations
+            try:
+                check_signature_compatible(subject_member, origin_type, attrname)
+            except TypeCheckError as exc:
+                raise TypeCheckError(
+                    f"is not compatible with the {origin_type.__qualname__} "
+                    f"protocol because its {attrname!r} method {exc}"
+                ) from None
 
 
 def check_byteslike(

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -9,6 +9,7 @@ import warnings
 from enum import Enum
 from inspect import Parameter, isclass, isfunction
 from io import BufferedIOBase, IOBase, RawIOBase, TextIOBase
+from itertools import zip_longest
 from textwrap import indent
 from typing import (
     IO,
@@ -87,7 +88,7 @@ if sys.version_info >= (3, 9):
     generic_alias_types += (types.GenericAlias,)
 
 protocol_check_cache: WeakKeyDictionary[
-    type[Any], dict[type[Any], TypeCheckError | None]
+    type[Any], dict[type[Any], tuple[Any, ...] | None]
 ] = WeakKeyDictionary()
 
 # Sentinel
@@ -638,6 +639,124 @@ def check_io(
         raise TypeCheckError("is not an I/O object")
 
 
+def check_signature_compatible(
+    subject_callable: Callable[..., Any], protocol: type, attrname: str
+) -> None:
+    subject_sig = inspect.signature(subject_callable)
+    protocol_sig = inspect.signature(getattr(protocol, attrname))
+
+    expected_varargs = any(
+        param
+        for param in protocol_sig.parameters.values()
+        if param.kind is Parameter.VAR_POSITIONAL
+    )
+    has_varargs = any(
+        param
+        for param in subject_sig.parameters.values()
+        if param.kind is Parameter.VAR_POSITIONAL
+    )
+    if expected_varargs and not has_varargs:
+        raise TypeCheckError("should accept variable positional arguments but doesn't")
+
+    protocol_has_varkwargs = any(
+        param
+        for param in protocol_sig.parameters.values()
+        if param.kind is Parameter.VAR_KEYWORD
+    )
+    subject_has_varkwargs = any(
+        param
+        for param in subject_sig.parameters.values()
+        if param.kind is Parameter.VAR_KEYWORD
+    )
+    if protocol_has_varkwargs and not subject_has_varkwargs:
+        raise TypeCheckError("should accept variable keyword arguments but doesn't")
+
+    # Check that the callable has at least the expect amount of positional-only
+    # arguments (and no extra positional-only arguments without default values)
+    if not has_varargs:
+        protocol_args = [
+            param
+            for param in protocol_sig.parameters.values()
+            if param.kind
+            in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        subject_args = [
+            param
+            for param in subject_sig.parameters.values()
+            if param.kind
+            in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+
+        # Remove the "self" parameter from methods
+        if inspect.ismethod(subject_callable) or inspect.ismethoddescriptor(
+            subject_callable
+        ):
+            protocol_args.pop(0)
+            subject_args.pop(0)
+
+        for protocol_arg, subject_arg in zip_longest(protocol_args, subject_args):
+            if protocol_arg is None:
+                if subject_arg.default is Parameter.empty:
+                    raise TypeCheckError("has too many mandatory positional arguments")
+
+                break
+
+            if subject_arg is None:
+                raise TypeCheckError("has too few positional arguments")
+
+            if (
+                protocol_arg.kind is Parameter.POSITIONAL_OR_KEYWORD
+                and subject_arg.kind is Parameter.POSITIONAL_ONLY
+            ):
+                raise TypeCheckError(
+                    f"has an argument ({subject_arg.name}) that should not be "
+                    f"positional-only"
+                )
+
+            if (
+                protocol_arg.kind is Parameter.POSITIONAL_OR_KEYWORD
+                and protocol_arg.name != subject_arg.name
+            ):
+                raise TypeCheckError(
+                    f"has a positional argument ({subject_arg.name}) that should be "
+                    f"named {protocol_arg.name!r} at this position"
+                )
+
+    protocol_kwonlyargs = {
+        param.name: param
+        for param in protocol_sig.parameters.values()
+        if param.kind is Parameter.KEYWORD_ONLY
+    }
+    subject_kwonlyargs = {
+        param.name: param
+        for param in subject_sig.parameters.values()
+        if param.kind is Parameter.KEYWORD_ONLY
+    }
+    if not subject_has_varkwargs:
+        # Check that the signature has at least the required keyword-only arguments, and
+        # no extra mandatory keyword-only arguments
+        if missing_kwonlyargs := [
+            param.name
+            for param in protocol_kwonlyargs.values()
+            if param.name not in subject_kwonlyargs
+        ]:
+            raise TypeCheckError(
+                "is missing keyword-only arguments: " + ", ".join(missing_kwonlyargs)
+            )
+
+    if not protocol_has_varkwargs:
+        if extra_kwonlyargs := [
+            param.name
+            for param in subject_kwonlyargs.values()
+            if param.default is Parameter.empty
+            and param.name not in protocol_kwonlyargs
+        ]:
+            raise TypeCheckError(
+                "has mandatory keyword-only arguments not present in the protocol: "
+                + ", ".join(extra_kwonlyargs)
+            )
+
+
 def check_protocol(
     value: Any,
     origin_type: Any,
@@ -649,82 +768,57 @@ def check_protocol(
     if subject in protocol_check_cache:
         result_map = protocol_check_cache[subject]
         if origin_type in result_map:
-            if exc := result_map[origin_type]:
-                raise exc
+            if exc_args := result_map[origin_type]:
+                raise TypeCheckError(*exc_args)
             else:
                 return
 
-    expected_methods: dict[str, tuple[Any, Any]] = {}
-    expected_noncallable_members: dict[str, Any] = {}
     origin_annotations = typing.get_type_hints(origin_type)
-
-    for attrname in typing_extensions.get_protocol_members(origin_type):
-        member = getattr(origin_type, attrname, None)
-
-        if callable(member):
-            signature = inspect.signature(member)
-            argtypes = [
-                (p.annotation if p.annotation is not Parameter.empty else Any)
-                for p in signature.parameters.values()
-                if p.kind is not Parameter.KEYWORD_ONLY
-            ] or Ellipsis
-            return_annotation = (
-                signature.return_annotation
-                if signature.return_annotation is not Parameter.empty
-                else Any
-            )
-            expected_methods[attrname] = argtypes, return_annotation
-        else:
-            try:
-                expected_noncallable_members[attrname] = origin_annotations[attrname]
-            except KeyError:
-                expected_noncallable_members[attrname] = member
-
-    subject_annotations = typing.get_type_hints(subject)
-
-    # Check that all required methods are present and their signatures are compatible
     result_map = protocol_check_cache.setdefault(subject, {})
     try:
-        for attrname, callable_args in expected_methods.items():
-            try:
-                method = getattr(subject, attrname)
-            except AttributeError:
-                if attrname in subject_annotations:
+        for attrname in sorted(typing_extensions.get_protocol_members(origin_type)):
+            if (annotation := origin_annotations.get(attrname)) is not None:
+                try:
+                    subject_member = getattr(subject, attrname)
+                except AttributeError:
                     raise TypeCheckError(
-                        f"is not compatible with the {origin_type.__qualname__} protocol "
-                        f"because its {attrname!r} attribute is not a method"
-                    ) from None
-                else:
-                    raise TypeCheckError(
-                        f"is not compatible with the {origin_type.__qualname__} protocol "
-                        f"because it has no method named {attrname!r}"
+                        f"is not compatible with the {origin_type.__qualname__} "
+                        f"protocol because it has no attribute named {attrname!r}"
                     ) from None
 
-            if not callable(method):
-                raise TypeCheckError(
-                    f"is not compatible with the {origin_type.__qualname__} protocol "
-                    f"because its {attrname!r} attribute is not a callable"
-                )
+                try:
+                    check_type_internal(subject_member, annotation, memo)
+                except TypeCheckError as exc:
+                    raise TypeCheckError(
+                        f"is not compatible with the {origin_type.__qualname__} "
+                        f"protocol because its {attrname!r} attribute {exc}"
+                    ) from None
+            elif callable(getattr(origin_type, attrname)):
+                try:
+                    subject_member = getattr(subject, attrname)
+                except AttributeError:
+                    raise TypeCheckError(
+                        f"is not compatible with the {origin_type.__qualname__} "
+                        f"protocol because it has no method named {attrname!r}"
+                    ) from None
 
-            # TODO: raise exception on added keyword-only arguments without defaults
-            try:
-                check_callable(method, Callable, callable_args, memo)
-            except TypeCheckError as exc:
-                raise TypeCheckError(
-                    f"is not compatible with the {origin_type.__qualname__} protocol "
-                    f"because its {attrname!r} method {exc}"
-                ) from None
+                if not callable(subject_member):
+                    raise TypeCheckError(
+                        f"is not compatible with the {origin_type.__qualname__} "
+                        f"protocol because its {attrname!r} attribute is not a callable"
+                    )
 
-        # Check that all required non-callable members are present
-        for attrname in expected_noncallable_members:
-            # TODO: implement assignability checks for non-callable members
-            if attrname not in subject_annotations and not hasattr(subject, attrname):
-                raise TypeCheckError(
-                    f"is not compatible with the {origin_type.__qualname__} protocol "
-                    f"because it has no attribute named {attrname!r}"
-                )
+                # TODO: implement assignability checks for parameter and return value
+                #  annotations
+                try:
+                    check_signature_compatible(subject_member, origin_type, attrname)
+                except TypeCheckError as exc:
+                    raise TypeCheckError(
+                        f"is not compatible with the {origin_type.__qualname__} "
+                        f"protocol because its {attrname!r} method {exc}"
+                    ) from None
     except TypeCheckError as exc:
-        result_map[origin_type] = exc
+        result_map[origin_type] = exc.args
         raise
     else:
         result_map[origin_type] = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,10 +6,8 @@ from typing import (
     List,
     NamedTuple,
     NewType,
-    Protocol,
     TypeVar,
     Union,
-    runtime_checkable,
 )
 
 T_Foo = TypeVar("T_Foo")
@@ -44,16 +42,3 @@ class Parent:
 class Child(Parent):
     def method(self, a: int) -> None:
         pass
-
-
-class StaticProtocol(Protocol):
-    member: int
-
-    def meth(self, x: str) -> None: ...
-
-
-@runtime_checkable
-class RuntimeProtocol(Protocol):
-    member: int
-
-    def meth(self, x: str) -> None: ...

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -1137,20 +1137,23 @@ class TestProtocol:
             def my_class_method(x: int, y: str) -> None:
                 pass
 
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            check_type(Foo(), MyProtocol)
+        check_type(Foo(), MyProtocol)
 
-    def test_missing_member(self) -> None:
+    @pytest.mark.parametrize("has_member", [True, False])
+    def test_member_checks(self, has_member: bool) -> None:
         class MyProtocol(Protocol):
             member: int
 
         class Foo:
-            pass
+            def __init__(self, member: int):
+                if member:
+                    self.member = member
 
-        obj = Foo()
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            pytest.raises(TypeCheckError, check_type, obj, MyProtocol).match(
-                f"^{qualified_name(obj)} is not compatible with the "
+        if has_member:
+            check_type(Foo(1), MyProtocol)
+        else:
+            pytest.raises(TypeCheckError, check_type, Foo(0), MyProtocol).match(
+                f"^{qualified_name(Foo)} is not compatible with the "
                 f"{MyProtocol.__qualname__} protocol because it has no attribute named "
                 f"'member'"
             )
@@ -1163,12 +1166,11 @@ class TestProtocol:
         class Foo:
             pass
 
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
-                f"^{qualified_name(Foo)} is not compatible with the "
-                f"{MyProtocol.__qualname__} protocol because it has no method named "
-                f"'meth'"
-            )
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because it has no method named "
+            f"'meth'"
+        )
 
     def test_too_many_posargs(self) -> None:
         class MyProtocol(Protocol):
@@ -1179,13 +1181,11 @@ class TestProtocol:
             def meth(self, x: str) -> None:
                 pass
 
-        obj = Foo()
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
-                f"^{qualified_name(obj)} is not compatible with the "
-                f"{MyProtocol.__qualname__} protocol because its 'meth' method has too "
-                f"many mandatory positional arguments"
-            )
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because its 'meth' method has too "
+            f"many mandatory positional arguments"
+        )
 
     def test_wrong_posarg_name(self) -> None:
         class MyProtocol(Protocol):
@@ -1196,13 +1196,11 @@ class TestProtocol:
             def meth(self, y: str) -> None:
                 pass
 
-        obj = Foo()
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
-                rf"^{qualified_name(obj)} is not compatible with the "
-                rf"{MyProtocol.__qualname__} protocol because its 'meth' method has a "
-                rf"positional argument \(y\) that should be named 'x' at this position"
-            )
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            rf"^{qualified_name(Foo)} is not compatible with the "
+            rf"{MyProtocol.__qualname__} protocol because its 'meth' method has a "
+            rf"positional argument \(y\) that should be named 'x' at this position"
+        )
 
     def test_too_few_posargs(self) -> None:
         class MyProtocol(Protocol):
@@ -1213,13 +1211,11 @@ class TestProtocol:
             def meth(self) -> None:
                 pass
 
-        obj = Foo()
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
-                f"^{qualified_name(obj)} is not compatible with the "
-                f"{MyProtocol.__qualname__} protocol because its 'meth' method has too "
-                f"few positional arguments"
-            )
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because its 'meth' method has too "
+            f"few positional arguments"
+        )
 
     def test_no_varargs(self) -> None:
         class MyProtocol(Protocol):
@@ -1230,13 +1226,11 @@ class TestProtocol:
             def meth(self) -> None:
                 pass
 
-        obj = Foo()
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
-                f"^{qualified_name(obj)} is not compatible with the "
-                f"{MyProtocol.__qualname__} protocol because its 'meth' method should "
-                f"accept variable positional arguments but doesn't"
-            )
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because its 'meth' method should "
+            f"accept variable positional arguments but doesn't"
+        )
 
     def test_no_kwargs(self) -> None:
         class MyProtocol(Protocol):
@@ -1247,13 +1241,11 @@ class TestProtocol:
             def meth(self) -> None:
                 pass
 
-        obj = Foo()
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
-                f"^{qualified_name(obj)} is not compatible with the "
-                f"{MyProtocol.__qualname__} protocol because its 'meth' method should "
-                f"accept variable keyword arguments but doesn't"
-            )
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because its 'meth' method should "
+            f"accept variable keyword arguments but doesn't"
+        )
 
     def test_missing_kwarg(self) -> None:
         class MyProtocol(Protocol):
@@ -1264,13 +1256,11 @@ class TestProtocol:
             def meth(self) -> None:
                 pass
 
-        obj = Foo()
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
-                f"^{qualified_name(obj)} is not compatible with the "
-                f"{MyProtocol.__qualname__} protocol because its 'meth' method is "
-                f"missing keyword-only arguments: x"
-            )
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because its 'meth' method is "
+            f"missing keyword-only arguments: x"
+        )
 
     def test_extra_kwarg(self) -> None:
         class MyProtocol(Protocol):
@@ -1281,13 +1271,43 @@ class TestProtocol:
             def meth(self, *, x: str) -> None:
                 pass
 
-        obj = Foo()
-        for _ in range(2):  # Makes sure that the cache is also exercised
-            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
-                f"^{qualified_name(obj)} is not compatible with the "
-                f"{MyProtocol.__qualname__} protocol because its 'meth' method has "
-                f"mandatory keyword-only arguments not present in the protocol: x"
-            )
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because its 'meth' method has "
+            f"mandatory keyword-only arguments not present in the protocol: x"
+        )
+
+    def test_instance_staticmethod_mismatch(self) -> None:
+        class MyProtocol(Protocol):
+            @staticmethod
+            def meth() -> None:
+                pass
+
+        class Foo:
+            def meth(self) -> None:
+                pass
+
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because its 'meth' method should "
+            f"be a static method but it's an instance method"
+        )
+
+    def test_instance_classmethod_mismatch(self) -> None:
+        class MyProtocol(Protocol):
+            @classmethod
+            def meth(cls) -> None:
+                pass
+
+        class Foo:
+            def meth(self) -> None:
+                pass
+
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because its 'meth' method should "
+            f"be a class method but it's an instance method"
+        )
 
 
 class TestRecursiveType:

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -54,8 +54,6 @@ from . import (
     Employee,
     JSONType,
     Parent,
-    RuntimeProtocol,
-    StaticProtocol,
     TChild,
     TIntStr,
     TParent,
@@ -1078,118 +1076,217 @@ class TestIntersectingProtocol:
             check_type(subject, predicate_type)
 
 
-@pytest.mark.parametrize(
-    "instantiate, annotation",
-    [
-        pytest.param(True, RuntimeProtocol, id="instance_runtime"),
-        pytest.param(False, Type[RuntimeProtocol], id="class_runtime"),
-        pytest.param(True, StaticProtocol, id="instance_static"),
-        pytest.param(False, Type[StaticProtocol], id="class_static"),
-    ],
-)
 class TestProtocol:
-    def test_member_defaultval(self, instantiate, annotation):
+    def test_success(self, typing_provider: Any) -> None:
+        class MyProtocol(Protocol):
+            member: int
+
+            def noargs(self) -> None:
+                pass
+
+            def posonlyargs(self, a: int, b: str, /) -> None:
+                pass
+
+            def posargs(self, a: int, b: str, c: float = 2.0) -> None:
+                pass
+
+            def varargs(self, *args: Any) -> None:
+                pass
+
+            def varkwargs(self, **kwargs: Any) -> None:
+                pass
+
+            def varbothargs(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            @staticmethod
+            def my_static_method(x: int, y: str) -> None:
+                pass
+
+            @classmethod
+            def my_class_method(cls, x: int, y: str) -> None:
+                pass
+
         class Foo:
             member = 1
 
-            def meth(self, x: str) -> None:
+            def noargs(self, x: int = 1) -> None:
                 pass
 
-        subject = Foo() if instantiate else Foo
+            def posonlyargs(self, a: int, b: str, c: float = 2.0, /) -> None:
+                pass
+
+            def posargs(self, *args: Any) -> None:
+                pass
+
+            def varargs(self, *args: Any, kwarg: str = "foo") -> None:
+                pass
+
+            def varkwargs(self, **kwargs: Any) -> None:
+                pass
+
+            def varbothargs(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            # These were intentionally reversed, as this is OK for mypy
+            @classmethod
+            def my_static_method(cls, x: int, y: str) -> None:
+                pass
+
+            @staticmethod
+            def my_class_method(x: int, y: str) -> None:
+                pass
+
         for _ in range(2):  # Makes sure that the cache is also exercised
-            check_type(subject, annotation)
+            check_type(Foo(), MyProtocol)
 
-    def test_member_annotation(self, instantiate, annotation):
-        class Foo:
+    def test_missing_member(self) -> None:
+        class MyProtocol(Protocol):
             member: int
 
+        class Foo:
+            pass
+
+        obj = Foo()
+        for _ in range(2):  # Makes sure that the cache is also exercised
+            pytest.raises(TypeCheckError, check_type, obj, MyProtocol).match(
+                f"^{qualified_name(obj)} is not compatible with the "
+                f"{MyProtocol.__qualname__} protocol because it has no attribute named "
+                f"'member'"
+            )
+
+    def test_missing_method(self) -> None:
+        class MyProtocol(Protocol):
+            def meth(self) -> None:
+                pass
+
+        class Foo:
+            pass
+
+        for _ in range(2):  # Makes sure that the cache is also exercised
+            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+                f"^{qualified_name(Foo)} is not compatible with the "
+                f"{MyProtocol.__qualname__} protocol because it has no method named "
+                f"'meth'"
+            )
+
+    def test_too_many_posargs(self) -> None:
+        class MyProtocol(Protocol):
+            def meth(self) -> None:
+                pass
+
+        class Foo:
             def meth(self, x: str) -> None:
                 pass
 
-        subject = Foo() if instantiate else Foo
-        for _ in range(2):
-            check_type(subject, annotation)
+        obj = Foo()
+        for _ in range(2):  # Makes sure that the cache is also exercised
+            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+                f"^{qualified_name(obj)} is not compatible with the "
+                f"{MyProtocol.__qualname__} protocol because its 'meth' method has too "
+                f"many mandatory positional arguments"
+            )
 
-    def test_attribute_missing(self, instantiate, annotation):
-        class Foo:
-            val = 1
-
+    def test_wrong_posarg_name(self) -> None:
+        class MyProtocol(Protocol):
             def meth(self, x: str) -> None:
                 pass
 
-        clsname = f"{__name__}.TestProtocol.test_attribute_missing.<locals>.Foo"
-        subject = Foo() if instantiate else Foo
-        for _ in range(2):
-            pytest.raises(TypeCheckError, check_type, subject, annotation).match(
-                f"{clsname} is not compatible with the (Runtime|Static)Protocol "
-                f"protocol because it has no attribute named 'member'"
-            )
-
-    def test_method_missing(self, instantiate, annotation):
         class Foo:
-            member: int
-
-        pattern = (
-            f"{__name__}.TestProtocol.test_method_missing.<locals>.Foo is not "
-            f"compatible with the (Runtime|Static)Protocol protocol because it has no "
-            f"method named 'meth'"
-        )
-        subject = Foo() if instantiate else Foo
-        for _ in range(2):
-            pytest.raises(TypeCheckError, check_type, subject, annotation).match(
-                pattern
-            )
-
-    def test_attribute_is_not_method_1(self, instantiate, annotation):
-        class Foo:
-            member: int
-            meth: str
-
-        pattern = (
-            f"{__name__}.TestProtocol.test_attribute_is_not_method_1.<locals>.Foo is "
-            f"not compatible with the (Runtime|Static)Protocol protocol because its "
-            f"'meth' attribute is not a method"
-        )
-        subject = Foo() if instantiate else Foo
-        for _ in range(2):
-            pytest.raises(TypeCheckError, check_type, subject, annotation).match(
-                pattern
-            )
-
-    def test_attribute_is_not_method_2(self, instantiate, annotation):
-        class Foo:
-            member: int
-            meth = "foo"
-
-        pattern = (
-            f"{__name__}.TestProtocol.test_attribute_is_not_method_2.<locals>.Foo is "
-            f"not compatible with the (Runtime|Static)Protocol protocol because its "
-            f"'meth' attribute is not a callable"
-        )
-        subject = Foo() if instantiate else Foo
-        for _ in range(2):
-            pytest.raises(TypeCheckError, check_type, subject, annotation).match(
-                pattern
-            )
-
-    def test_method_signature_mismatch(self, instantiate, annotation):
-        class Foo:
-            member: int
-
-            def meth(self, x: str, y: int) -> None:
+            def meth(self, y: str) -> None:
                 pass
 
-        pattern = (
-            rf"(class )?{__name__}.TestProtocol.test_method_signature_mismatch."
-            rf"<locals>.Foo is not compatible with the (Runtime|Static)Protocol "
-            rf"protocol because its 'meth' method has too many mandatory positional "
-            rf"arguments in its declaration; expected 2 but 3 mandatory positional "
-            rf"argument\(s\) declared"
-        )
-        subject = Foo() if instantiate else Foo
-        for _ in range(2):
-            pytest.raises(TypeCheckError, check_type, subject, annotation).match(
-                pattern
+        obj = Foo()
+        for _ in range(2):  # Makes sure that the cache is also exercised
+            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+                rf"^{qualified_name(obj)} is not compatible with the "
+                rf"{MyProtocol.__qualname__} protocol because its 'meth' method has a "
+                rf"positional argument \(y\) that should be named 'x' at this position"
+            )
+
+    def test_too_few_posargs(self) -> None:
+        class MyProtocol(Protocol):
+            def meth(self, x: str) -> None:
+                pass
+
+        class Foo:
+            def meth(self) -> None:
+                pass
+
+        obj = Foo()
+        for _ in range(2):  # Makes sure that the cache is also exercised
+            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+                f"^{qualified_name(obj)} is not compatible with the "
+                f"{MyProtocol.__qualname__} protocol because its 'meth' method has too "
+                f"few positional arguments"
+            )
+
+    def test_no_varargs(self) -> None:
+        class MyProtocol(Protocol):
+            def meth(self, *args: Any) -> None:
+                pass
+
+        class Foo:
+            def meth(self) -> None:
+                pass
+
+        obj = Foo()
+        for _ in range(2):  # Makes sure that the cache is also exercised
+            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+                f"^{qualified_name(obj)} is not compatible with the "
+                f"{MyProtocol.__qualname__} protocol because its 'meth' method should "
+                f"accept variable positional arguments but doesn't"
+            )
+
+    def test_no_kwargs(self) -> None:
+        class MyProtocol(Protocol):
+            def meth(self, **kwargs: Any) -> None:
+                pass
+
+        class Foo:
+            def meth(self) -> None:
+                pass
+
+        obj = Foo()
+        for _ in range(2):  # Makes sure that the cache is also exercised
+            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+                f"^{qualified_name(obj)} is not compatible with the "
+                f"{MyProtocol.__qualname__} protocol because its 'meth' method should "
+                f"accept variable keyword arguments but doesn't"
+            )
+
+    def test_missing_kwarg(self) -> None:
+        class MyProtocol(Protocol):
+            def meth(self, *, x: str) -> None:
+                pass
+
+        class Foo:
+            def meth(self) -> None:
+                pass
+
+        obj = Foo()
+        for _ in range(2):  # Makes sure that the cache is also exercised
+            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+                f"^{qualified_name(obj)} is not compatible with the "
+                f"{MyProtocol.__qualname__} protocol because its 'meth' method is "
+                f"missing keyword-only arguments: x"
+            )
+
+    def test_extra_kwarg(self) -> None:
+        class MyProtocol(Protocol):
+            def meth(self) -> None:
+                pass
+
+        class Foo:
+            def meth(self, *, x: str) -> None:
+                pass
+
+        obj = Foo()
+        for _ in range(2):  # Makes sure that the cache is also exercised
+            pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+                f"^{qualified_name(obj)} is not compatible with the "
+                f"{MyProtocol.__qualname__} protocol because its 'meth' method has "
+                f"mandatory keyword-only arguments not present in the protocol: x"
             )
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #465.

This adds proper checking of protocol method signatures instead of using `check_callable()` which does not deal with keyword arguments.
<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [X] You've added tests (in `tests/`) added which would fail without your patch
- [X] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [X] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the pytest plugin (#999
<https://github.com/agronholm/typeguard/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
