### PR TITLE
Further improvement on typeguard_ignore() annotation

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -5,7 +5,7 @@ This library adheres to
 `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
 - Changed the signature of ``typeguard_ignore()`` to be compatible with
-  `typing.no_type_check()` (PR by @jolaf)
+  ``typing.no_type_check()`` (PR by @jolaf)
 
 **4.4.0** (2024-10-27)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,6 +4,10 @@ Version history
 This library adheres to
 `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
+- Made sure that `typeguard_ignore()` signature is fully compatible
+  with `typing.no_type_check()`
+  (`#497 <https://github.com/agronholm/typeguard/pull/497>`_; PR by @jolaf)
+
 **4.4.0** (2024-10-27)
 
 - Added proper checking for method signatures in protocol checks

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,9 +4,8 @@ Version history
 This library adheres to
 `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
-- Made sure that `typeguard_ignore()` signature is fully compatible
-  with `typing.no_type_check()`
-  (`#497 <https://github.com/agronholm/typeguard/pull/497>`_; PR by @jolaf)
+- Changed the signature of ``typeguard_ignore()`` to be compatible with
+  `typing.no_type_check()` (PR by @jolaf)
 
 **4.4.0** (2024-10-27)
 

--- a/src/typeguard/_decorators.py
+++ b/src/typeguard/_decorators.py
@@ -16,19 +16,17 @@ from ._functions import TypeCheckFailCallback
 from ._transformer import TypeguardTransformer
 from ._utils import Unset, function_name, get_stacklevel, is_method_of, unset
 
+T_CallableOrType = TypeVar("T_CallableOrType", bound=Callable[..., Any])
+
 if TYPE_CHECKING:
     from typeshed.stdlib.types import _Cell
 
-    _F = TypeVar("_F")
-
-    def typeguard_ignore(f: _F) -> _F:
+    def typeguard_ignore(f: T_CallableOrType) -> T_CallableOrType:
         """This decorator is a noop during static type-checking."""
         return f
 
 else:
     from typing import no_type_check as typeguard_ignore  # noqa: F401
-
-T_CallableOrType = TypeVar("T_CallableOrType", bound=Callable[..., Any])
 
 
 def make_cell(value: object) -> _Cell:

--- a/src/typeguard/_decorators.py
+++ b/src/typeguard/_decorators.py
@@ -21,9 +21,9 @@ T_CallableOrType = TypeVar("T_CallableOrType", bound=Callable[..., Any])
 if TYPE_CHECKING:
     from typeshed.stdlib.types import _Cell
 
-    def typeguard_ignore(f: T_CallableOrType) -> T_CallableOrType:
+    def typeguard_ignore(arg: T_CallableOrType) -> T_CallableOrType:
         """This decorator is a noop during static type-checking."""
-        return f
+        return arg
 
 else:
     from typing import no_type_check as typeguard_ignore  # noqa: F401


### PR DESCRIPTION
Unfortunately, it turned out that #485 was not enough to make `mypy` fully happy.
So this is a followup.

See https://github.com/python/mypy/issues/18060 for details.
