### PR TITLE
use full name for Attributes

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,6 +4,11 @@ Version history
 This library adheres to
 `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
+**UNRELEASED**
+
+* Fixed ``TypeCheckError`` when tuple unpacking to properties of method parameter
+  (`#506 <https://github.com/agronholm/typeguard/issues/506>`_) (PR by @fefe982)
+
 **4.4.1** (2024-11-03)
 
 - Dropped Python 3.8 support

--- a/src/typeguard/_functions.py
+++ b/src/typeguard/_functions.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import inspect
 import sys
 import warnings
 from collections.abc import Sequence
 from typing import Any, Callable, NoReturn, TypeVar, Union, overload
-import inspect
 
 from . import _suppression
 from ._checkers import BINARY_MAGIC_METHODS, check_type_internal

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -1048,7 +1048,7 @@ class TypeguardTransformer(NodeTransformer):
             check_required = False
             for target in node.targets:
                 elts: Sequence[expr]
-                if isinstance(target, Name):
+                if isinstance(target, (Name, Attribute)):
                     elts = [target]
                 elif isinstance(target, Tuple):
                     elts = target.elts
@@ -1073,7 +1073,7 @@ class TypeguardTransformer(NodeTransformer):
 
                         path.insert(0, exp.id)
                         name = prefix + ".".join(path)
-                        annotation = self._memo.variable_annotations.get(exp.id)
+                        annotation = self._memo.variable_annotations.get(name)
                         if annotation:
                             annotations_.append((Constant(name), annotation))
                             check_required = True

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -1073,7 +1073,7 @@ class TypeguardTransformer(NodeTransformer):
 
                         path.insert(0, exp.id)
                         name = prefix + ".".join(path)
-                        annotation = self._memo.variable_annotations.get(name)
+                        annotation = self._memo.variable_annotations.get(exp.id)
                         if annotation:
                             annotations_.append((Constant(name), annotation))
                             check_required = True

--- a/tests/dummymodule.py
+++ b/tests/dummymodule.py
@@ -2,6 +2,7 @@
 
 import sys
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -268,6 +269,25 @@ def unpacking_assign_star_no_annotation(value: Any) -> Tuple[int, List[bytes], s
     z: str
     x, *y, z = value
     return x, y, z
+
+
+@dataclass
+class Foo:
+    bar: str = "bar"
+    baz: int = 123
+
+
+@typechecked
+def attribute_assign_separate(obj: Foo) -> Foo:
+    obj.bar = "barbar"
+    obj.baz = 123123
+    return obj
+
+
+@typechecked
+def attribute_assign_unpacking(obj: Foo) -> Foo:
+    obj.bar, obj.baz = ("barbar", 123123)
+    return obj
 
 
 @typechecked(forward_ref_policy=ForwardRefPolicy.ERROR)

--- a/tests/dummymodule.py
+++ b/tests/dummymodule.py
@@ -290,6 +290,19 @@ def attribute_assign_unpacking(obj: Foo) -> Foo:
     return obj
 
 
+@typechecked
+def attribute_assign_separate_fail(obj: Foo) -> Foo:
+    obj.bar = 123
+    obj.baz = 123123
+    return obj
+
+
+@typechecked
+def attribute_assign_unpacking_fail(obj: Foo) -> Foo:
+    obj.bar, obj.baz = (123, 123123)
+    return obj
+
+
 @typechecked(forward_ref_policy=ForwardRefPolicy.ERROR)
 def override_forward_ref_policy(value: "NonexistentType") -> None:  # noqa: F821
     pass

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -257,6 +257,18 @@ def test_unpacking_assign_star_no_annotation_fail(dummymodule):
         dummymodule.unpacking_assign_star_no_annotation((1, b"abc", b"bah", b"foo"))
 
 
+def test_attribute_assign_separate(dummymodule):
+    assert dummymodule.attribute_assign_separate(dummymodule.Foo()) == dummymodule.Foo(
+        "barbar", 123123
+    )
+
+
+def test_attribute_assign_unpacking(dummymodule):
+    assert dummymodule.attribute_assign_unpacking(dummymodule.Foo()) == dummymodule.Foo(
+        "barbar", 123123
+    )
+
+
 class TestOptionsOverride:
     def test_forward_ref_policy(self, dummymodule):
         with pytest.raises(NameError, match="name 'NonexistentType' is not defined"):

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -269,6 +269,22 @@ def test_attribute_assign_unpacking(dummymodule):
     )
 
 
+def test_attribute_assign_separate_fail(dummymodule):
+    with pytest.raises(
+        TypeCheckError,
+        match=r"value assigned to obj.bar \(int\) is not an instance of str",
+    ):
+        dummymodule.attribute_assign_separate_fail(dummymodule.Foo())
+
+
+def test_attribute_assign_unpacking_fail(dummymodule):
+    with pytest.raises(
+        TypeCheckError,
+        match=r"value assigned to obj.bar \(int\) is not an instance of str",
+    ):
+        dummymodule.attribute_assign_unpacking_fail(dummymodule.Foo())
+
+
 class TestOptionsOverride:
     def test_forward_ref_policy(self, dummymodule):
         with pytest.raises(NameError, match="name 'NonexistentType' is not defined"):

--- a/tests/test_warn_on_error.py
+++ b/tests/test_warn_on_error.py
@@ -1,5 +1,5 @@
-from typing import List
 import os
+from typing import List
 
 import pytest
 

--- a/tests/test_warn_on_error.py
+++ b/tests/test_warn_on_error.py
@@ -1,4 +1,5 @@
 from typing import List
+import os
 
 import pytest
 
@@ -10,7 +11,12 @@ def test_check_type(recwarn):
         check_type(1, str, typecheck_fail_callback=warn_on_error)
 
     assert len(warning.list) == 1
-    assert warning.list[0].filename == __file__
+    if (
+        os.name == "nt"
+    ):  # file path name (and drive letter) is case insensitive on windows
+        assert warning.list[0].filename.lower() == __file__.lower()
+    else:
+        assert warning.list[0].filename == __file__
     assert warning.list[0].lineno == test_check_type.__code__.co_firstlineno + 2
 
 
@@ -24,5 +30,8 @@ def test_typechecked(monkeypatch, recwarn):
         foo()
 
     assert len(warning.list) == 1
-    assert warning.list[0].filename == __file__
+    if os.name == "nt":
+        assert warning.list[0].filename.lower() == __file__.lower()
+    else:
+        assert warning.list[0].filename == __file__
     assert warning.list[0].lineno == test_typechecked.__code__.co_firstlineno + 3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #506

In assignment check, when attribute is added:

1. `Attribute` is only handled in tuple, but not bare attribute assignments. Add check for bare attribute assignment
2. `exp.id` is used for `Attribute`, but for `Attribute`, it points to the parent object, not the attribute. Changed it to use `name` ，which is `obj.attr`, the full path.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
