### PR TITLE
fix #510

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,6 +11,7 @@ This library adheres to
   regression introduced in v4.4.1)
 - Fixed display of module name for forward references
   (`#492 <https://github.com/agronholm/typeguard/pull/492>`_; PR by @JelleZijlstra)
+- Fixed ``TypeError`` when using := (`#510 <https://github.com/agronholm/typeguard/issues/510>`_; PR: `#511 <https://github.com/agronholm/typeguard/pull/511>`_; PR by `@JohannesK71083 <https://github.com/JohannesK71083>`_)
 
 **4.4.1** (2024-11-03)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -11,7 +11,8 @@ This library adheres to
   regression introduced in v4.4.1)
 - Fixed display of module name for forward references
   (`#492 <https://github.com/agronholm/typeguard/pull/492>`_; PR by @JelleZijlstra)
-- Fixed ``TypeError`` when using := (`#510 <https://github.com/agronholm/typeguard/issues/510>`_; PR: `#511 <https://github.com/agronholm/typeguard/pull/511>`_; PR by `@JohannesK71083 <https://github.com/JohannesK71083>`_)
+- Fixed ``TypeError`` when using an assignment expression
+  (`#510 <https://github.com/agronholm/typeguard/issues/510>`_; PR by @JohannesK71083)
 
 **4.4.1** (2024-11-03)
 

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -1138,8 +1138,11 @@ class TypeguardTransformer(NodeTransformer):
                 func_name,
                 [
                     node.value,
-                    Constant(node.target.id),
-                    annotation,
+                    List([
+                        List(
+                            [Tuple([Constant(node.target.id), annotation], ctx=Load())], ctx=Load(),
+                        )], ctx=Load()
+                    ),
                     self._memo.get_memo_name(),
                 ],
                 [],

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -1138,10 +1138,19 @@ class TypeguardTransformer(NodeTransformer):
                 func_name,
                 [
                     node.value,
-                    List([
-                        List(
-                            [Tuple([Constant(node.target.id), annotation], ctx=Load())], ctx=Load(),
-                        )], ctx=Load()
+                    List(
+                        [
+                            List(
+                                [
+                                    Tuple(
+                                        [Constant(node.target.id), annotation],
+                                        ctx=Load(),
+                                    )
+                                ],
+                                ctx=Load(),
+                            )
+                        ],
+                        ctx=Load(),
                     ),
                     self._memo.get_memo_name(),
                 ],

--- a/tests/mypy/test_type_annotations.py
+++ b/tests/mypy/test_type_annotations.py
@@ -31,7 +31,7 @@ def get_negative_mypy_output() -> str:
     )
     output = process.stdout.decode()
     assert output
-    return re.sub(r'\n(?!\s|negative\.py)', ' ', output.replace("\r", ""))
+    return re.sub(r"\n(?!\s|negative\.py)", " ", output.replace("\r", ""))
 
 
 def get_expected_errors() -> Dict[int, str]:

--- a/tests/mypy/test_type_annotations.py
+++ b/tests/mypy/test_type_annotations.py
@@ -31,7 +31,7 @@ def get_negative_mypy_output() -> str:
     )
     output = process.stdout.decode()
     assert output
-    return output
+    return re.sub(r'\n(?!\s|negative\.py)', ' ', output.replace("\r", ""))
 
 
 def get_expected_errors() -> Dict[int, str]:

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1475,7 +1475,7 @@ check_variable_assignment
                 def foo() -> None:
                     memo = TypeCheckMemo(globals(), locals())
                     x: int
-                    if (x := check_variable_assignment(otherfunc(), 'x', int, \
+                    if (x := check_variable_assignment(otherfunc(), [[('x', int)]], \
 memo)):
                         pass
                 """
@@ -1504,7 +1504,7 @@ check_variable_assignment
                 def foo(x: int) -> None:
                     memo = TypeCheckMemo(globals(), locals())
                     check_argument_types('foo', {'x': (x, int)}, memo)
-                    if (x := check_variable_assignment(otherfunc(), 'x', int, memo)):
+                    if (x := check_variable_assignment(otherfunc(), [[('x', int)]], memo)):
                         pass
                 """
             ).strip()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #510

<!-- Please give a short brief about these changes. -->
In 889ad53 the parameters of check_variable_assignment in _functions.py were changed but one call in _transformer.py wasn't adjusted. Fixed by adjusting mentioned call and changing tests accordingly.
Furthermore, I had to change how the test handles mypy output because otherwise I couldn't get the tests to pass (even on the unmodified version). (see 5336b1c)

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).
