### PR TITLE
Add support for dataclasses in `check_type()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/
+.venv/

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -166,6 +166,8 @@ The following types from the standard library have specialized support:
    * - | :class:`typing.Callable`
        | :class:`collections.abc.Callable`
      - Argument count is checked but types are not (yet)
+   * - | :func:`dataclasses.dataclass`
+     - Object attribute values match dataclass field types
    * - | :class:`dict`
        | :class:`typing.Dict`
      - Keys and values are typechecked

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -9,6 +9,8 @@ This library adheres to
 - Fixed ``@typechecked`` unable to find the target function or method if it or the
   containing class had PEP 695 type parameters on them
   (`#500 <https://github.com/agronholm/typeguard/issues/500>`_)
+- Added support for dataclasses in ``check_type()``
+  (`#524 <https://github.com/agronholm/typeguard/issues/524>`_)
 
 **4.4.2** (2025-02-16)
 

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -872,7 +872,6 @@ def check_dataclass(
                 f"is not compatible with the {origin_type.__qualname__} "
                 f"because it has no attribute named {field.name!r}"
             ) from None
-        check_type_internal(getattr(value, field.name), field.type, memo)
 
         try:
             check_type_internal(subject_member, field.type, memo)

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -282,7 +282,7 @@ class TestDataclass:
     def test_valid_optional(self):
         @dataclass
         class D:
-            x: str | None
+            x: Union[str, None]
 
         C = namedtuple("C", "x")
         check_type(C("A"), D)


### PR DESCRIPTION
## Changes

Fixes #524.

Objects can now be checked against classes decorated with `@dataclass`. Object attribute values are passed to `check_type()` with dataclass field type.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [v] You've added tests (in `tests/`) added which would fail without your patch
- [v] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [v] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the pytest plugin (#999
<https://github.com/agronholm/typeguard/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
