### PR TITLE
small change: add PyPI link in README via badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://img.shields.io/pypi/v/typeguard
+  :target: https://pypi.org/project/typeguard/
+  :alt: PyPI Link
 .. image:: https://github.com/agronholm/typeguard/actions/workflows/test.yml/badge.svg
   :target: https://github.com/agronholm/typeguard/actions/workflows/test.yml
   :alt: Build Status


### PR DESCRIPTION
I was checking out this repo earlier but couldn't find a PyPI link. I thought it would be a good idea to include one.

Lmk if you have any questions 👍