### PR TITLE
Recognize wildcard-imported Literal annotations

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,9 @@ This library adheres to
 
 **UNRELEASED**
 
+- Added reconition of wildcard imports from ``typing`` and ``typing_extensions`` in the
+  import hook/instrumenter
+  (`#489 <https://github.com/agronholm/typeguard/issues/489>`_; PR by @ShipitAndPray)
 - Fixed compatibility with Python 3.15
   (`#554 <https://github.com/agronholm/typeguard/pull/554>`_; PR by @hrnciar)
 - Fixed an assignment expression against an annotated name (``x: int``, then

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -614,7 +614,10 @@ class TypeguardTransformer(NodeTransformer):
 
     def visit_ImportFrom(self, node: ImportFrom) -> ImportFrom:
         for name in node.names:
-            if name.name != "*":
+            if name.name == "*" and node.module in {"typing", "typing_extensions"}:
+                self._memo.local_names.add("Literal")
+                self._memo.imported_names["Literal"] = f"{node.module}.Literal"
+            elif name.name != "*":
                 alias = name.asname or name.name
                 self._memo.local_names.add(alias)
                 self._memo.imported_names[alias] = f"{node.module}.{name.name}"

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -62,6 +62,9 @@ from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, cast, overload
+from typing import __all__ as typing_all
+
+from typing_extensions import __all__ as typing_extensions_all
 
 PreliminaryNameTypePair: typing.TypeAlias = tuple[Constant, "expr | None"]
 NameTypePair: typing.TypeAlias = tuple[Constant, expr]
@@ -603,10 +606,19 @@ class TypeguardTransformer(NodeTransformer):
 
     def visit_ImportFrom(self, node: ImportFrom) -> ImportFrom:
         for name in node.names:
-            if name.name == "*" and node.module in {"typing", "typing_extensions"}:
-                self._memo.local_names.add("Literal")
-                self._memo.imported_names["Literal"] = f"{node.module}.Literal"
-            elif name.name != "*":
+            if name.name == "*":
+                match node.module:
+                    case "typing":
+                        imported_names = typing_all
+                    case "typing_extensions":
+                        imported_names = typing_extensions_all
+                    case _:
+                        continue
+
+                for item in imported_names:
+                    self._memo.local_names.add(item)
+                    self._memo.imported_names.setdefault(item, f"{node.module}.{item}")
+            else:
                 alias = name.asname or name.name
                 self._memo.local_names.add(alias)
                 self._memo.imported_names[alias] = f"{node.module}.{name.name}"

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -2008,3 +2008,32 @@ def test_literal() -> None:
             """
         ).strip()
     )
+
+
+def test_literal_wildcard_import() -> None:
+    # Regression test for #489
+    node = parse(
+        dedent(
+            """
+            from typing import *
+
+            def foo(x: Literal['a', 'b']) -> None:
+                pass
+            """
+        )
+    )
+    TypeguardTransformer().visit(node)
+    assert (
+        unparse(node)
+        == dedent(
+            """
+            from typeguard import TypeCheckMemo
+            from typeguard._functions import check_argument_types_internal
+            from typing import *
+
+            def foo(x: Literal['a', 'b']) -> None:
+                memo = TypeCheckMemo(globals(), locals())
+                check_argument_types_internal('foo', {'x': (x, Literal['a', 'b'])}, memo)
+            """
+        ).strip()
+    )


### PR DESCRIPTION
## Summary
- recognize bare `Literal` as a typing import when it comes from `from typing import *` or `from typing_extensions import *`
- keep the fix narrow to the existing `Literal` special-case in the transformer
- add focused regression coverage for wildcard-imported `Literal` annotations

Closes #489

## Testing
- `uv run pytest tests/test_transformer.py -q -k literal_wildcard_import`
- `uv run pytest tests/test_transformer.py -q`
- baseline repro used a one-off script with `from typing import *` plus `@typechecked` and failed before this change with `NameError: name 'hi' is not defined`