### PR TITLE
Fixed crash in protocol check when subject method has no positional params

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,6 +4,12 @@ Version history
 This library adheres to
 `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
+**UNRELEASED**
+
+- Fixed ``IndexError`` raised from ``check_signature_compatible`` when the subject
+  method has no positional parameters
+  (`#550 <https://github.com/agronholm/typeguard/issues/550>`_; PR by @HackedRico)
+
 **4.5.1** (2026-02-19)
 
 - Fixed iterable unpacking incorrectly calculating the cut-off offset of the item list

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -761,11 +761,11 @@ def check_signature_compatible(subject: type, protocol: type, attrname: str) -> 
         ]
 
         # Remove the "self" parameter from the protocol arguments to match
-        if protocol_type == "instance":
+        if protocol_type == "instance" and protocol_args:
             protocol_args.pop(0)
 
         # Remove the "self" parameter from the subject arguments to match
-        if subject_type == "instance":
+        if subject_type == "instance" and subject_args:
             subject_args.pop(0)
 
         for protocol_arg, subject_arg in zip_longest(protocol_args, subject_args):

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -1405,8 +1405,8 @@ class TestProtocol:
         )
 
     def test_subject_method_no_positional_params(self) -> None:
-        class _ZeroArg:
-            def __call__(self):
+        class ZeroArg:
+            def __call__(self) -> None:
                 return None
 
         class MyProtocol(Protocol):
@@ -1414,7 +1414,7 @@ class TestProtocol:
                 pass
 
         class Foo:
-            meth = _ZeroArg()
+            meth = ZeroArg()
 
         pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
             f"^{qualified_name(Foo)} is not compatible with the "

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -1404,6 +1404,24 @@ class TestProtocol:
             f"few positional arguments"
         )
 
+    def test_subject_method_no_positional_params(self) -> None:
+        class _ZeroArg:
+            def __call__(self):
+                return None
+
+        class MyProtocol(Protocol):
+            def meth(self, x: str) -> None:
+                pass
+
+        class Foo:
+            meth = _ZeroArg()
+
+        pytest.raises(TypeCheckError, check_type, Foo(), MyProtocol).match(
+            f"^{qualified_name(Foo)} is not compatible with the "
+            f"{MyProtocol.__qualname__} protocol because its 'meth' method has too "
+            f"few positional arguments"
+        )
+
     def test_no_varargs(self) -> None:
         class MyProtocol(Protocol):
             def meth(self, *args: Any) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## Changes

Fixes #550

<!-- Please give a short brief about these changes. -->

`check_signature_compatible` in `src/typeguard/_checkers.py` calls `.pop(0)` on `protocol_args` and `subject_args` to strip the implicit `self`, but does so unconditionally whenever the corresponding side is classified as `"instance"`. If the subject method's `inspect.signature(...)` reports zero positional-or-keyword parameters and no `*args` (e.g. a callable instance assigned at class scope, a `functools.partial` with all positional args bound, or a method proxied by a code-generation framework), `subject_args` is empty and `pop(0)` raises `IndexError` instead of letting the function fall through to its existing `zip_longest` comparison and emit a `TypeCheckError`.

This guards each pop with a non-empty check. After the change, the previously-crashing input raises `TypeCheckError("... has too few positional arguments")` along the same path as the equivalent N → N-1 mismatch with one more arg, restoring `check_type`'s documented contract that callers can catch via `except TypeCheckError`.

Regression test added under `tests/test_checkers.py::TestProtocol::test_subject_method_no_positional_params`.

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog


- Fixed crash in protocol check when subject method has no positional params (`#550 <https://github.com/agronholm/typeguard/issues/550>`_; PR by @HackedRico)
