### PR TITLE
Fix compatibility with Python 3.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", pypy-3.11]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15", pypy-3.11]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -4,6 +4,11 @@ Version history
 This library adheres to
 `Semantic Versioning 2.0 <https://semver.org/#semantic-versioning-200>`_.
 
+**UNRELEASED**
+
+- Compatibility with Python 3.15, drop removed debug_override parameter from cache_from_source()
+  call (`#554 <https://github.com/agronholm/typeguard/pull/554>`_; PR by @hrnciar)
+
 **4.5.2** (2026-05-14)
 
 - Fixed ``IndexError`` raised from ``check_signature_compatible`` when the subject

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,8 +6,9 @@ This library adheres to
 
 **UNRELEASED**
 
-- Compatibility with Python 3.15, drop removed debug_override parameter from cache_from_source()
-  call (`#554 <https://github.com/agronholm/typeguard/pull/554>`_; PR by @hrnciar)
+- Fixed compatibility with Python 3.15, drop removed debug_override parameter from
+  cache_from_source() call
+  (`#554 <https://github.com/agronholm/typeguard/pull/554>`_; PR by @hrnciar)
 
 **4.5.2** (2026-05-14)
 

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,8 +6,7 @@ This library adheres to
 
 **UNRELEASED**
 
-- Fixed compatibility with Python 3.15, drop removed debug_override parameter from
-  cache_from_source() call
+- Fixed compatibility with Python 3.15
   (`#554 <https://github.com/agronholm/typeguard/pull/554>`_; PR by @hrnciar)
 
 **4.5.2** (2026-05-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
 ]
 requires-python = ">= 3.9"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ pretty = true
 files = ["src"]
 
 [tool.tox]
-env_list = ["py39", "py310", "py311", "py312", "py313", "py314"]
+env_list = ["py39", "py310", "py311", "py312", "py313", "py314", "py315"]
 skip_missing_interpreters = true
 requires = ["tox >= 4.22"]
 

--- a/src/typeguard/_importhook.py
+++ b/src/typeguard/_importhook.py
@@ -99,7 +99,13 @@ class TypeguardLoader(SourceFileLoader):
             print("----------------------------------------------", file=sys.stderr)
 
         return _call_with_frames_removed(
-            compile, tree, filename, "exec", 0, dont_inherit=True, **extra_kwargs
+            compile,
+            tree,
+            filename,
+            "exec",
+            0,
+            dont_inherit=True,
+            **extra_kwargs
         )
 
     def exec_module(self, module: ModuleType) -> None:

--- a/src/typeguard/_importhook.py
+++ b/src/typeguard/_importhook.py
@@ -74,12 +74,21 @@ class TypeguardLoader(SourceFileLoader):
             else:
                 source = decode_source(data)
 
-            module = _call_with_frames_removed(
-                ast.parse,
-                source,
-                filename,
-                "exec",
-            )
+            if sys.version_info >= (3,15):
+                module = _call_with_frames_removed(
+                    ast.parse,
+                    source,
+                    filename,
+                    "exec",
+                    module=fullname,
+                )
+            else:
+                module = _call_with_frames_removed(
+                    ast.parse,
+                    source,
+                    filename,
+                    "exec",
+                )
 
         tree = TypeguardTransformer().visit(module)
         ast.fix_missing_locations(tree)
@@ -93,9 +102,14 @@ class TypeguardLoader(SourceFileLoader):
             print(ast.unparse(tree), file=sys.stderr)
             print("----------------------------------------------", file=sys.stderr)
 
-        return _call_with_frames_removed(
-            compile, tree, filename, "exec", 0, dont_inherit=True
-        )
+        if sys.version_info >= (3, 15):
+            return _call_with_frames_removed(
+                compile, tree, filename, "exec", 0, dont_inherit=True, module=fullname,
+            )
+        else:
+            return _call_with_frames_removed(
+                compile, tree, filename, "exec", 0, dont_inherit=True,
+            )
 
     def exec_module(self, module: ModuleType) -> None:
         # Use a custom optimization marker – the import lock should make this monkey

--- a/src/typeguard/_importhook.py
+++ b/src/typeguard/_importhook.py
@@ -66,10 +66,6 @@ class TypeguardLoader(SourceFileLoader):
         else:
             filename = os.fsdecode(bytes(path))
 
-        extra_kwargs = {}
-        if sys.version_info >= (3, 15):
-            extra_kwargs["module"] = fullname
-
         if isinstance(data, (ast.Module, ast.Expression, ast.Interactive)):
             module = data
         else:
@@ -78,13 +74,21 @@ class TypeguardLoader(SourceFileLoader):
             else:
                 source = decode_source(data)
 
-            module = _call_with_frames_removed(
-                ast.parse,
-                source,
-                filename,
-                "exec",
-                **extra_kwargs,
-            )
+            if sys.version_info >= (3, 15):
+                module = _call_with_frames_removed(
+                    ast.parse,
+                    source,
+                    filename,
+                    "exec",
+                    module=fullname,
+                )
+            else:
+                module = _call_with_frames_removed(
+                    ast.parse,
+                    source,
+                    filename,
+                    "exec",
+                )
 
         tree = TypeguardTransformer().visit(module)
         ast.fix_missing_locations(tree)
@@ -98,15 +102,25 @@ class TypeguardLoader(SourceFileLoader):
             print(ast.unparse(tree), file=sys.stderr)
             print("----------------------------------------------", file=sys.stderr)
 
-        return _call_with_frames_removed(
-            compile,
-            tree,
-            filename,
-            "exec",
-            0,
-            dont_inherit=True,
-            **extra_kwargs
-        )
+        if sys.version_info >= (3, 15):
+            return _call_with_frames_removed(
+                compile,
+                tree,
+                filename,
+                "exec",
+                0,
+                dont_inherit=True,
+                module=fullname,
+            )
+        else:
+            return _call_with_frames_removed(
+                compile,
+                tree,
+                filename,
+                "exec",
+                0,
+                dont_inherit=True,
+            )
 
     def exec_module(self, module: ModuleType) -> None:
         # Use a custom optimization marker – the import lock should make this monkey

--- a/src/typeguard/_importhook.py
+++ b/src/typeguard/_importhook.py
@@ -66,6 +66,10 @@ class TypeguardLoader(SourceFileLoader):
         else:
             filename = os.fsdecode(bytes(path))
 
+        extra_kwargs = {}
+        if sys.version_info >= (3, 15):
+            extra_kwargs["module"] = fullname
+
         if isinstance(data, (ast.Module, ast.Expression, ast.Interactive)):
             module = data
         else:
@@ -74,21 +78,13 @@ class TypeguardLoader(SourceFileLoader):
             else:
                 source = decode_source(data)
 
-            if sys.version_info >= (3, 15):
-                module = _call_with_frames_removed(
-                    ast.parse,
-                    source,
-                    filename,
-                    "exec",
-                    module=fullname,
-                )
-            else:
-                module = _call_with_frames_removed(
-                    ast.parse,
-                    source,
-                    filename,
-                    "exec",
-                )
+            module = _call_with_frames_removed(
+                ast.parse,
+                source,
+                filename,
+                "exec",
+                **extra_kwargs,
+            )
 
         tree = TypeguardTransformer().visit(module)
         ast.fix_missing_locations(tree)
@@ -102,25 +98,15 @@ class TypeguardLoader(SourceFileLoader):
             print(ast.unparse(tree), file=sys.stderr)
             print("----------------------------------------------", file=sys.stderr)
 
-        if sys.version_info >= (3, 15):
-            return _call_with_frames_removed(
-                compile,
-                tree,
-                filename,
-                "exec",
-                0,
-                dont_inherit=True,
-                module=fullname,
-            )
-        else:
-            return _call_with_frames_removed(
-                compile,
-                tree,
-                filename,
-                "exec",
-                0,
-                dont_inherit=True,
-            )
+        return _call_with_frames_removed(
+            compile,
+            tree,
+            filename,
+            "exec",
+            0,
+            dont_inherit=True,
+            **extra_kwargs
+        )
 
     def exec_module(self, module: ModuleType) -> None:
         # Use a custom optimization marker – the import lock should make this monkey

--- a/src/typeguard/_importhook.py
+++ b/src/typeguard/_importhook.py
@@ -48,8 +48,8 @@ def _call_with_frames_removed(
     return f(*args, **kwargs)
 
 
-def optimized_cache_from_source(path: str, debug_override: bool | None = None) -> str:
-    return cache_from_source(path, debug_override, optimization=OPTIMIZATION)
+def optimized_cache_from_source(path: str) -> str:
+    return cache_from_source(path, optimization=OPTIMIZATION)
 
 
 class TypeguardLoader(SourceFileLoader):
@@ -57,6 +57,7 @@ class TypeguardLoader(SourceFileLoader):
     def source_to_code(
         data: Buffer | str | ast.Module | ast.Expression | ast.Interactive,
         path: Buffer | str | PathLike[str] = "<string>",
+        fullname: str | None = None,
         *,
         _optimize: int = -1,
     ) -> CodeType:

--- a/src/typeguard/_importhook.py
+++ b/src/typeguard/_importhook.py
@@ -74,7 +74,7 @@ class TypeguardLoader(SourceFileLoader):
             else:
                 source = decode_source(data)
 
-            if sys.version_info >= (3,15):
+            if sys.version_info >= (3, 15):
                 module = _call_with_frames_removed(
                     ast.parse,
                     source,
@@ -104,11 +104,22 @@ class TypeguardLoader(SourceFileLoader):
 
         if sys.version_info >= (3, 15):
             return _call_with_frames_removed(
-                compile, tree, filename, "exec", 0, dont_inherit=True, module=fullname,
+                compile,
+                tree,
+                filename,
+                "exec",
+                0,
+                dont_inherit=True,
+                module=fullname,
             )
         else:
             return _call_with_frames_removed(
-                compile, tree, filename, "exec", 0, dont_inherit=True,
+                compile,
+                tree,
+                filename,
+                "exec",
+                0,
+                dont_inherit=True,
             )
 
     def exec_module(self, module: ModuleType) -> None:

--- a/src/typeguard/_importhook.py
+++ b/src/typeguard/_importhook.py
@@ -99,13 +99,7 @@ class TypeguardLoader(SourceFileLoader):
             print("----------------------------------------------", file=sys.stderr)
 
         return _call_with_frames_removed(
-            compile,
-            tree,
-            filename,
-            "exec",
-            0,
-            dont_inherit=True,
-            **extra_kwargs
+            compile, tree, filename, "exec", 0, dont_inherit=True, **extra_kwargs
         )
 
     def exec_module(self, module: ModuleType) -> None:

--- a/src/typeguard/_importhook.py
+++ b/src/typeguard/_importhook.py
@@ -11,7 +11,7 @@ from importlib.util import cache_from_source, decode_source
 from inspect import isclass
 from os import PathLike
 from types import CodeType, ModuleType, TracebackType
-from typing import Any, TypeVar
+from typing import TypeVar
 from unittest.mock import patch
 
 from ._config import global_config
@@ -66,7 +66,7 @@ class TypeguardLoader(SourceFileLoader):
         else:
             filename = os.fsdecode(bytes(path))
 
-        extra_kwargs: dict[str, Any] = {}
+        extra_kwargs = {}
         if sys.version_info >= (3, 15):
             extra_kwargs["module"] = fullname
 

--- a/src/typeguard/_importhook.py
+++ b/src/typeguard/_importhook.py
@@ -11,7 +11,7 @@ from importlib.util import cache_from_source, decode_source
 from inspect import isclass
 from os import PathLike
 from types import CodeType, ModuleType, TracebackType
-from typing import TypeVar
+from typing import Any, TypeVar
 from unittest.mock import patch
 
 from ._config import global_config
@@ -66,7 +66,7 @@ class TypeguardLoader(SourceFileLoader):
         else:
             filename = os.fsdecode(bytes(path))
 
-        extra_kwargs = {}
+        extra_kwargs: dict[str, Any] = {}
         if sys.version_info >= (3, 15):
             extra_kwargs["module"] = fullname
 

--- a/tests/dummymodule.py
+++ b/tests/dummymodule.py
@@ -18,7 +18,6 @@ from typing import (
     TypeVar,
     Union,
     no_type_check,
-    no_type_check_decorator,
     overload,
 )
 
@@ -42,6 +41,7 @@ P = ParamSpec("P")
 
 
 if sys.version_info <= (3, 13):
+    from typing import no_type_check_decorator
 
     @no_type_check_decorator
     def dummy_decorator(func):


### PR DESCRIPTION
- Drop removed debug_override parameter from cache_from_source() call
- Accept extra positional args in source_to_code() for new fullname parameter
- Guard no_type_check_decorator import behind version check (removed in 3.15)

Assisted-by: Cursor

<!-- Thank you for your contribution! -->
## Changes

Fixes #. <!-- Provide issue number if exists -->

<!-- Please give a short brief about these changes. -->

## Checklist

If this is a user-facing code change, like a bugfix or a new feature, please ensure that
you've fulfilled the following conditions (where applicable):

- [ ] You've added tests (in `tests/`) added which would fail without your patch
- [ ] You've updated the documentation (in `docs/`, in case of behavior changes or new
features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

If this is a trivial change, like a typo fix or a code reformatting, then you can ignore
these instructions.

### Updating the changelog

If there are no entries after the last release, use `**UNRELEASED**` as the version.
If, say, your patch fixes issue #999, the entry should look like this:

`* Fix big bad boo-boo in the pytest plugin (#999
<https://github.com/agronholm/typeguard/issues/999>_; PR by @yourgithubaccount)`

If there's no issue linked, just link to your pull request instead by updating the
changelog after you've created the PR.
