### PR TITLE
Fix false positive checking a class against type[Protocol] with instance attributes

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,10 +6,6 @@ This library adheres to
 
 **UNRELEASED**
 
-- Fixed false positive when checking a class against ``type[SomeProtocol]`` where the
-  protocol declares non-``ClassVar`` (instance) attributes; only ``ClassVar`` members
-  are now required on the class itself
-  (`#499 <https://github.com/agronholm/typeguard/issues/499>`_)
 - Fixed compatibility with Python 3.15
   (`#554 <https://github.com/agronholm/typeguard/pull/554>`_; PR by @hrnciar)
 - Fixed an assignment expression against an annotated name (``x: int``, then
@@ -17,6 +13,10 @@ This library adheres to
   ``TypeError`` for a non-iterable value and silently replaced an iterable value with
   ``list(value)``
   (`#557 <https://github.com/agronholm/typeguard/issues/557>`_)
+- Fixed false positive when checking a class against ``type[SomeProtocol]`` where the
+  protocol declares non-``ClassVar`` (instance) attributes; only ``ClassVar`` members
+  are now required on the class itself
+  (`#499 <https://github.com/agronholm/typeguard/issues/499>`_)
 - Dropped support for Python 3.9
 
 **4.5.2** (2026-05-14)

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,10 @@ This library adheres to
 
 **UNRELEASED**
 
+- Fixed false positive when checking a class against ``type[SomeProtocol]`` where the
+  protocol declares non-``ClassVar`` (instance) attributes; only ``ClassVar`` members
+  are now required on the class itself
+  (`#499 <https://github.com/agronholm/typeguard/issues/499>`_)
 - Fixed compatibility with Python 3.15
   (`#554 <https://github.com/agronholm/typeguard/pull/554>`_; PR by @hrnciar)
 - Dropped support for Python 3.9

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -839,9 +839,9 @@ def check_protocol(
     for attrname in sorted(typing_extensions.get_protocol_members(origin_type)):
         if (annotation := origin_annotations.get(attrname)) is not None:
             if checking_class and typing.get_origin(annotation) is not typing.ClassVar:
-                # A non-ClassVar annotation describes an instance attribute
-                # (PEP 544). A class object is not expected to have it set, and
-                # static type checkers accept this, so don't flag it as missing.
+                # a non-ClassVar annotation is an instance attribute (PEP 544) —
+                # a class object isn't expected to have it set, and type
+                # checkers accept that, so don't flag it as missing.
                 continue
 
             try:

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -835,8 +835,15 @@ def check_protocol(
     memo: TypeCheckMemo,
 ) -> None:
     origin_annotations = typing.get_type_hints(origin_type)
+    checking_class = isclass(value)
     for attrname in sorted(typing_extensions.get_protocol_members(origin_type)):
         if (annotation := origin_annotations.get(attrname)) is not None:
+            if checking_class and typing.get_origin(annotation) is not typing.ClassVar:
+                # A non-ClassVar annotation describes an instance attribute
+                # (PEP 544). A class object is not expected to have it set, and
+                # static type checkers accept this, so don't flag it as missing.
+                continue
+
             try:
                 subject_member = getattr(value, attrname)
             except AttributeError:

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -14,6 +14,7 @@ from typing import (
     AnyStr,
     BinaryIO,
     Callable,
+    ClassVar,
     Collection,
     Concatenate,
     ContextManager,
@@ -1341,6 +1342,36 @@ class TestProtocol:
                 f"{MyProtocol.__qualname__} protocol because it has no attribute named "
                 f"'member'"
             )
+
+    def test_class_against_protocol_ignores_instance_attributes(self) -> None:
+        # Checking a class (not an instance) against type[Protocol] must not
+        # flag instance attributes as missing; only ClassVar members are
+        # required on the class itself. See issue #499.
+        class MyProtocol(Protocol):
+            foo: str
+
+        class Foo:
+            def __init__(self) -> None:
+                self.foo = "bar"
+
+        check_type(Foo, type[MyProtocol])
+
+    def test_class_against_protocol_requires_classvar(self) -> None:
+        class MyProtocol(Protocol):
+            bar: ClassVar[int]
+
+        class Missing:
+            pass
+
+        pytest.raises(TypeCheckError, check_type, Missing, type[MyProtocol]).match(
+            f"is not compatible with the {MyProtocol.__qualname__} protocol "
+            f"because it has no attribute named 'bar'"
+        )
+
+        class Present:
+            bar = 3
+
+        check_type(Present, type[MyProtocol])
 
     def test_missing_method(self) -> None:
         class MyProtocol(Protocol):


### PR DESCRIPTION
Fixes #499

Checking a class (not an instance) against `type[SomeProtocol]` raised a false-positive `TypeCheckError` when the protocol declared a non-`ClassVar` attribute that the class sets in `__init__`:

```python
class Proto(Protocol):
    foo: str

class Foo:
    def __init__(self) -> None:
        self.foo = "bar"

check_type(Foo, type[Proto])   # raised, though mypy/pyright accept it
```

Per PEP 544, an attribute annotation without `ClassVar` describes an *instance* attribute, so a class object is not expected to carry it. This implements the approach you outlined in the issue: when the subject is a class, `check_protocol` now ignores non-`ClassVar` attribute annotations and only requires the `ClassVar` ones to be present on the class. Instance checks are unchanged, and method/callable checks are untouched.

Added two regression tests: a class satisfying a protocol via an instance attribute no longer raises, and a class missing a required `ClassVar` member still does. The full `tests/test_checkers.py` suite passes.
