### PR TITLE
Fix walrus (:=) assignments to annotated variables mishandled as tuple-unpacking

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,11 @@ This library adheres to
 
 **UNRELEASED**
 
+- Fixed walrus (``:=``) assignments to an annotated variable being instrumented
+  as if they were tuple-unpacking assignments, causing a spurious ``TypeError``
+  for non-iterable values and silent corruption (via ``list(value)``) of
+  iterable values
+  (`#557 <https://github.com/agronholm/typeguard/issues/557>`_)
 - Fixed compatibility with Python 3.15
   (`#554 <https://github.com/agronholm/typeguard/pull/554>`_; PR by @hrnciar)
 - Dropped support for Python 3.9

--- a/src/typeguard/_transformer.py
+++ b/src/typeguard/_transformer.py
@@ -1150,13 +1150,8 @@ class TypeguardTransformer(NodeTransformer):
                     node.value,
                     List(
                         [
-                            List(
-                                [
-                                    Tuple(
-                                        [Constant(node.target.id), annotation],
-                                        ctx=Load(),
-                                    )
-                                ],
+                            Tuple(
+                                [Constant(node.target.id), annotation],
                                 ctx=Load(),
                             )
                         ],

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1513,7 +1513,7 @@ check_variable_assignment
                 def foo() -> None:
                     memo = TypeCheckMemo(globals(), locals())
                     x: int
-                    if (x := check_variable_assignment(otherfunc(), [[('x', int)]], \
+                    if (x := check_variable_assignment(otherfunc(), [('x', int)], \
 memo)):
                         pass
                 """
@@ -1542,7 +1542,7 @@ check_variable_assignment
                 def foo(x: int) -> None:
                     memo = TypeCheckMemo(globals(), locals())
                     check_argument_types_internal('foo', {'x': (x, int)}, memo)
-                    if (x := check_variable_assignment(otherfunc(), [[('x', int)]], memo)):
+                    if (x := check_variable_assignment(otherfunc(), [('x', int)], memo)):
                         pass
                 """
             ).strip()

--- a/tests/test_typechecked.py
+++ b/tests/test_typechecked.py
@@ -708,3 +708,63 @@ def test_duplicate_function():
 
     assert foo1() == [0, 1, 2, 3, 4]
     assert foo() == [5, 6, 7, 8, 9]
+
+
+def test_walrus_assignment_valid():
+    """Regression test for
+    https://github.com/agronholm/typeguard/issues/557
+
+    A walrus (``:=``) assignment to an annotated variable was
+    instrumented with a doubly-nested target list (as used for
+    tuple-unpacking assignments), causing check_variable_assignment()
+    to treat it as an unpacking assignment and call list(value) on it.
+    For a non-iterable value this raised a spurious TypeError; for an
+    iterable value (e.g. a str) it silently corrupted the assigned
+    value instead of preserving it.
+    """
+
+    @typechecked
+    def case_int() -> int:
+        x: int = 0
+        if (x := 5) > 0:
+            pass
+        return x
+
+    assert case_int() == 5
+
+    @typechecked
+    def case_iterable() -> str:
+        x: str = "init"
+        if x := "abc":
+            pass
+        return x
+
+    # Previously this silently returned ['a', 'b', 'c'] instead of "abc".
+    assert case_iterable() == "abc"
+
+    @typechecked
+    def case_none() -> None:
+        x: int | None = 1
+        if (x := None) is not None:
+            pass
+
+    # Previously this raised TypeError: 'NoneType' object is not
+    # iterable, instead of succeeding (None is a valid int | None).
+    assert case_none() is None
+
+
+def test_walrus_assignment_invalid():
+    """A walrus assignment of a value that doesn't match the
+    annotation should raise TypeCheckError, same as a plain annotated
+    assignment would -- not an internal TypeError from mishandling the
+    check's target format.
+    """
+
+    @typechecked
+    def case_annotated_arg(x: int) -> None:
+        if (x := None) is None:
+            pass
+
+    with pytest.raises(TypeCheckError):
+        case_annotated_arg(1)
+

--- a/tests/test_typechecked.py
+++ b/tests/test_typechecked.py
@@ -767,4 +767,3 @@ def test_walrus_assignment_invalid():
 
     with pytest.raises(TypeCheckError):
         case_annotated_arg(1)
-


### PR DESCRIPTION
Fixes #557.

`TypeguardTransformer.visit_NamedExpr()` built the `check_variable_assignment()` target argument as a doubly-nested list: `[[('x', annotation)]]`. Every other single-target call site (e.g. `visit_AnnAssign()`, used for plain `x: T = value`) builds it as a single-nested list: `[('x', annotation)]`.

`check_variable_assignment()` distinguishes single-target from tuple-unpacking assignments purely by whether each element of the outer `groups` list is itself a list (unpacking) or a bare tuple (single target). The extra list layer around the walrus operator's target therefore made every walrus assignment to an annotated variable look like a tuple-unpacking assignment, triggering `list(value)` on the right-hand side:

- Non-iterable values (`None`, `int`, ...) raised a spurious internal `TypeError` instead of being type-checked normally.
- Iterable values (`str`, `list`, ...) didn't raise, but the assigned variable was silently replaced by `list(value)` -- e.g. a string `"abc"` became `['a', 'b', 'c']` -- corrupting the variable's value without any error being surfaced.

As diagnosed precisely in the issue.

**Fix**: remove the extra `List` wrapper so the walrus operator's single target is built the same way as every other single-target call site.

**Testing**: added runtime regression tests covering the exact scenarios from the issue -- a non-iterable value (previously a spurious `TypeError`), an iterable value (previously silent corruption), and confirmation that an actually-invalid assignment (`None` to an `int`-annotated variable) now correctly raises `TypeCheckError` instead of an unrelated internal `TypeError`. I confirmed both new tests fail with the original code and pass with the fix.

I also updated two existing AST-snapshot tests in `test_transformer.py` that were asserting the old, incorrect `[[('x', int)]]` structure as expected output -- they were unknowingly encoding this bug into the test suite. The analogous plain-assignment test in the same file already asserts the correct `[('x', int)]` format, confirming this was purely a walrus-specific inconsistency.

Ran the full existing test suite: 396 passed (394 baseline + 2 new), 3 skipped, 3 xfailed, matching the baseline exactly aside from the new tests. The 4 remaining failures (2 missing `mypy` binary, 2 pytest deprecation-warning related) are present identically on a clean checkout of `master` and are unrelated environment/dependency issues in my sandbox.