### PR TITLE
Check the contents of deque annotations

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,8 @@ This library adheres to
 
 **UNRELEASED**
 
+- Added type checking of the contents of ``deque`` annotations
+  (``Deque[int]``/``collections.deque[int]``); the item type was previously ignored
 - Fixed ``ReadOnly`` (:pep:`705`) qualifiers on ``TypedDict`` items being left
   unwrapped, which caused the item's value type to skip type checking entirely
   (`#571 <https://github.com/agronholm/typeguard/pull/571>`_; PR by @jaideeppyne)

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -21,6 +21,7 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
+    Deque,
     Dict,
     ForwardRef,
     List,
@@ -327,6 +328,25 @@ def check_list(
 ) -> None:
     if not isinstance(value, list):
         raise TypeCheckError("is not a list")
+
+    if args and args != (Any,):
+        samples = memo.config.collection_check_strategy.iterate_samples(value)
+        for i, v in enumerate(samples):
+            try:
+                check_type_internal(v, args[0], memo)
+            except TypeCheckError as exc:
+                exc.append_path_element(f"item {i}")
+                raise
+
+
+def check_deque(
+    value: Any,
+    origin_type: Any,
+    args: tuple[Any, ...],
+    memo: TypeCheckMemo,
+) -> None:
+    if not isinstance(value, collections.deque):
+        raise TypeCheckError("is not a deque")
 
     if args and args != (Any,):
         samples = memo.config.collection_check_strategy.iterate_samples(value)
@@ -1056,6 +1076,8 @@ origin_type_checkers: dict[
     None: check_none,
     collections.abc.Mapping: check_mapping,
     collections.abc.MutableMapping: check_mapping,
+    collections.deque: check_deque,
+    Deque: check_deque,
     Sequence: check_sequence,
     collections.abc.Sequence: check_sequence,
     collections.abc.Set: check_set,

--- a/src/typeguard/_config.py
+++ b/src/typeguard/_config.py
@@ -34,6 +34,7 @@ class CollectionCheckStrategy(Enum):
     This has an effect on the following built-in checkers:
 
     * ``AbstractSet``
+    * ``Deque``
     * ``Dict``
     * ``List``
     * ``Mapping``

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -1,6 +1,7 @@
 import collections.abc
 import sys
 import types
+from collections import deque
 from contextlib import nullcontext
 from datetime import timedelta
 from functools import partial
@@ -18,6 +19,7 @@ from typing import (
     Collection,
     Concatenate,
     ContextManager,
+    Deque,
     Dict,
     ForwardRef,
     FrozenSet,
@@ -759,6 +761,38 @@ class TestList:
             List[int],
             collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS,
         ).match("list is not an instance of int")
+
+
+class TestDeque:
+    def test_bad_type(self):
+        pytest.raises(TypeCheckError, check_type, 5, Deque[int]).match(
+            "int is not a deque"
+        )
+
+    def test_list_is_not_a_deque(self):
+        pytest.raises(TypeCheckError, check_type, [1], Deque[int]).match(
+            "list is not a deque"
+        )
+
+    def test_first_check_success(self):
+        check_type(deque(["aa", "bb", 1]), Deque[str])
+
+    def test_first_check_empty(self):
+        check_type(deque(), Deque[str])
+
+    def test_first_check_fail(self):
+        pytest.raises(TypeCheckError, check_type, deque(["bb"]), Deque[int]).match(
+            "deque is not an instance of int"
+        )
+
+    def test_full_check_fail(self):
+        pytest.raises(
+            TypeCheckError,
+            check_type,
+            deque([1, 2, "bb"]),
+            Deque[int],
+            collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS,
+        ).match("deque is not an instance of int")
 
 
 class TestSequence:


### PR DESCRIPTION
`collections.deque` has no checker registered, so it falls through to a plain `isinstance` and the item type is dropped:

check_type(deque(["a"]), Deque[int])  
check_sequence would have covered the contents, but it accepts any Sequence, which would let a plain list through as a Deque. The new checker mirrors check_list and tests for deque itself.