### PR TITLE
Check the contents of dictionary view annotations

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,9 @@ This library adheres to
 
 **UNRELEASED**
 
+- Added type checking of the contents of dictionary view annotations
+  (``KeysView``, ``ValuesView`` and ``ItemsView``); the item types were previously
+  ignored
 - Fixed ``ReadOnly`` (:pep:`705`) qualifiers on ``TypedDict`` items being left
   unwrapped, which caused the item's value type to skip type checking entirely
   (`#571 <https://github.com/agronholm/typeguard/pull/571>`_; PR by @jaideeppyne)

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -23,6 +23,8 @@ from typing import (
     Callable,
     Dict,
     ForwardRef,
+    ItemsView,
+    KeysView,
     List,
     NewType,
     Set,
@@ -32,6 +34,7 @@ from typing import (
     TypeGuard,
     TypeVar,
     Union,
+    ValuesView,
 )
 from unittest.mock import Mock
 
@@ -336,6 +339,55 @@ def check_list(
             except TypeCheckError as exc:
                 exc.append_path_element(f"item {i}")
                 raise
+
+
+def check_keys_or_values_view(
+    value: Any,
+    origin_type: Any,
+    args: tuple[Any, ...],
+    memo: TypeCheckMemo,
+) -> None:
+    if origin_type in (KeysView, collections.abc.KeysView):
+        if not isinstance(value, collections.abc.KeysView):
+            raise TypeCheckError("is not a keys view")
+    elif not isinstance(value, collections.abc.ValuesView):
+        raise TypeCheckError("is not a values view")
+
+    if args and args != (Any,):
+        samples = memo.config.collection_check_strategy.iterate_samples(value)
+        for v in samples:
+            try:
+                check_type_internal(v, args[0], memo)
+            except TypeCheckError as exc:
+                exc.append_path_element(f"[{v!r}]")
+                raise
+
+
+def check_items_view(
+    value: Any,
+    origin_type: Any,
+    args: tuple[Any, ...],
+    memo: TypeCheckMemo,
+) -> None:
+    if not isinstance(value, collections.abc.ItemsView):
+        raise TypeCheckError("is not an items view")
+
+    if args:
+        key_type, value_type = args
+        if key_type is not Any or value_type is not Any:
+            samples = memo.config.collection_check_strategy.iterate_samples(value)
+            for k, v in samples:
+                try:
+                    check_type_internal(k, key_type, memo)
+                except TypeCheckError as exc:
+                    exc.append_path_element(f"key {k!r}")
+                    raise
+
+                try:
+                    check_type_internal(v, value_type, memo)
+                except TypeCheckError as exc:
+                    exc.append_path_element(f"value of key {k!r}")
+                    raise
 
 
 def check_sequence(
@@ -1048,6 +1100,10 @@ origin_type_checkers: dict[
     float: check_number,
     frozenset: check_set,
     IO: check_io,
+    collections.abc.ItemsView: check_items_view,
+    ItemsView: check_items_view,
+    collections.abc.KeysView: check_keys_or_values_view,
+    KeysView: check_keys_or_values_view,
     list: check_list,
     List: check_list,
     typing.Literal: check_literal,
@@ -1067,6 +1123,8 @@ origin_type_checkers: dict[
     type: check_class,
     Type: check_class,
     TypeGuard: check_typeguard,
+    collections.abc.ValuesView: check_keys_or_values_view,
+    ValuesView: check_keys_or_values_view,
     Union: check_union,
     UnionType: check_uniontype,
     # On some versions of Python, these may simply be re-exports from "typing",

--- a/src/typeguard/_config.py
+++ b/src/typeguard/_config.py
@@ -35,9 +35,12 @@ class CollectionCheckStrategy(Enum):
 
     * ``AbstractSet``
     * ``Dict``
+    * ``ItemsView``
+    * ``KeysView``
     * ``List``
     * ``Mapping``
     * ``Set``
+    * ``ValuesView``
     * ``Tuple[<type>, ...]`` (arbitrarily sized tuples)
 
     Members:

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -21,8 +21,10 @@ from typing import (
     Dict,
     ForwardRef,
     FrozenSet,
+    ItemsView,
     Iterable,
     Iterator,
+    KeysView,
     List,
     Literal,
     Mapping,
@@ -38,6 +40,7 @@ from typing import (
     TypeGuard,
     TypeVar,
     Union,
+    ValuesView,
 )
 
 import pytest
@@ -759,6 +762,94 @@ class TestList:
             List[int],
             collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS,
         ).match("list is not an instance of int")
+
+
+class TestKeysView:
+    def test_bad_type(self):
+        pytest.raises(TypeCheckError, check_type, [1], KeysView[int]).match(
+            "list is not a keys view"
+        )
+
+    def test_first_check_success(self):
+        check_type({"aa": 1, "bb": 2}.keys(), KeysView[str])
+
+    def test_first_check_empty(self):
+        check_type({}.keys(), KeysView[str])
+
+    def test_first_check_fail(self):
+        pytest.raises(
+            TypeCheckError, check_type, {"aa": 1}.keys(), KeysView[int]
+        ).match("dict_keys is not an instance of int")
+
+    def test_full_check_fail(self):
+        pytest.raises(
+            TypeCheckError,
+            check_type,
+            {1: None, 2: None, "cc": None}.keys(),
+            KeysView[int],
+            collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS,
+        ).match("dict_keys is not an instance of int")
+
+
+class TestValuesView:
+    def test_bad_type(self):
+        pytest.raises(TypeCheckError, check_type, [1], ValuesView[int]).match(
+            "list is not a values view"
+        )
+
+    def test_keys_view_is_not_a_values_view(self):
+        pytest.raises(
+            TypeCheckError, check_type, {"aa": 1}.keys(), ValuesView[str]
+        ).match("dict_keys is not a values view")
+
+    def test_first_check_success(self):
+        check_type({"aa": 1, "bb": 2}.values(), ValuesView[int])
+
+    def test_first_check_fail(self):
+        pytest.raises(
+            TypeCheckError, check_type, {"aa": 1}.values(), ValuesView[str]
+        ).match("dict_values is not an instance of str")
+
+    def test_full_check_fail(self):
+        pytest.raises(
+            TypeCheckError,
+            check_type,
+            {"aa": 1, "bb": 2, "cc": "x"}.values(),
+            ValuesView[int],
+            collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS,
+        ).match("dict_values is not an instance of int")
+
+
+class TestItemsView:
+    def test_bad_type(self):
+        pytest.raises(TypeCheckError, check_type, [1], ItemsView[str, int]).match(
+            "list is not an items view"
+        )
+
+    def test_first_check_success(self):
+        check_type({"aa": 1, "bb": 2}.items(), ItemsView[str, int])
+
+    def test_first_check_empty(self):
+        check_type({}.items(), ItemsView[str, int])
+
+    def test_bad_key_type(self):
+        pytest.raises(
+            TypeCheckError, check_type, {"aa": 1}.items(), ItemsView[int, int]
+        ).match("dict_items is not an instance of int")
+
+    def test_bad_value_type(self):
+        pytest.raises(
+            TypeCheckError, check_type, {"aa": 1}.items(), ItemsView[str, str]
+        ).match("dict_items is not an instance of str")
+
+    def test_full_check_fail(self):
+        pytest.raises(
+            TypeCheckError,
+            check_type,
+            {"aa": 1, "bb": "x"}.items(),
+            ItemsView[str, int],
+            collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS,
+        ).match("dict_items is not an instance of int")
 
 
 class TestSequence:


### PR DESCRIPTION
KeysView, ValuesView and ItemsView have no checkers registered, so their arguments get dropped:

    d = {"a": 1}
    check_type(d.keys(), KeysView[int])         # passes
    check_type(d.items(), ItemsView[int, str])  # passes - the exact reverse

The views are checked elementwise like the other collections. ItemsView follows check_mapping in reporting the key and the value separately