### PR TITLE
Check the contents of ChainMap, defaultdict and OrderedDict annotations

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,9 @@ This library adheres to
 
 **UNRELEASED**
 
+- Added type checking of the contents of ``ChainMap``, ``defaultdict`` and
+  ``OrderedDict`` annotations; the key and value types were previously ignored, and a
+  plain ``dict`` was accepted for any of them
 - Fixed ``ReadOnly`` (:pep:`705`) qualifiers on ``TypedDict`` items being left
   unwrapped, which caused the item's value type to skip type checking entirely
   (`#571 <https://github.com/agronholm/typeguard/pull/571>`_; PR by @jaideeppyne)

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -21,10 +21,13 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
+    ChainMap,
+    DefaultDict,
     Dict,
     ForwardRef,
     List,
     NewType,
+    OrderedDict,
     Set,
     TextIO,
     Tuple,
@@ -217,6 +220,16 @@ def check_callable(
                 )
 
 
+_concrete_mapping_types: dict[Any, type] = {
+    ChainMap: collections.ChainMap,
+    collections.ChainMap: collections.ChainMap,
+    DefaultDict: collections.defaultdict,
+    collections.defaultdict: collections.defaultdict,
+    OrderedDict: collections.OrderedDict,
+    collections.OrderedDict: collections.OrderedDict,
+}
+
+
 def check_mapping(
     value: Any,
     origin_type: Any,
@@ -226,6 +239,9 @@ def check_mapping(
     if origin_type is Dict or origin_type is dict:
         if not isinstance(value, dict):
             raise TypeCheckError("is not a dict")
+    elif concrete_type := _concrete_mapping_types.get(origin_type):
+        if not isinstance(value, concrete_type):
+            raise TypeCheckError(f"is not a {concrete_type.__name__}")
     if origin_type is MutableMapping or origin_type is collections.abc.MutableMapping:
         if not isinstance(value, collections.abc.MutableMapping):
             raise TypeCheckError("is not a mutable mapping")
@@ -1056,6 +1072,12 @@ origin_type_checkers: dict[
     None: check_none,
     collections.abc.Mapping: check_mapping,
     collections.abc.MutableMapping: check_mapping,
+    collections.ChainMap: check_mapping,
+    ChainMap: check_mapping,
+    collections.defaultdict: check_mapping,
+    DefaultDict: check_mapping,
+    collections.OrderedDict: check_mapping,
+    OrderedDict: check_mapping,
     Sequence: check_sequence,
     collections.abc.Sequence: check_sequence,
     collections.abc.Set: check_set,

--- a/src/typeguard/_config.py
+++ b/src/typeguard/_config.py
@@ -34,9 +34,12 @@ class CollectionCheckStrategy(Enum):
     This has an effect on the following built-in checkers:
 
     * ``AbstractSet``
+    * ``ChainMap``
+    * ``defaultdict``
     * ``Dict``
     * ``List``
     * ``Mapping``
+    * ``OrderedDict``
     * ``Set``
     * ``Tuple[<type>, ...]`` (arbitrarily sized tuples)
 

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -14,10 +14,12 @@ from typing import (
     AnyStr,
     BinaryIO,
     Callable,
+    ChainMap,
     ClassVar,
     Collection,
     Concatenate,
     ContextManager,
+    DefaultDict,
     Dict,
     ForwardRef,
     FrozenSet,
@@ -27,6 +29,7 @@ from typing import (
     Literal,
     Mapping,
     MutableMapping,
+    OrderedDict,
     ParamSpec,
     Protocol,
     Sequence,
@@ -446,6 +449,51 @@ class TestDict:
                     yield key, self[key]
 
         check_type(CustomDict(a=1), Dict[str, int])
+
+
+class TestMappingSubclasses:
+    @pytest.mark.parametrize(
+        ("annotation", "factory", "type_name"),
+        [
+            pytest.param(ChainMap, collections.ChainMap, "ChainMap", id="chainmap"),
+            pytest.param(
+                DefaultDict,
+                lambda d: collections.defaultdict(int, d),
+                "defaultdict",
+                id="defaultdict",
+            ),
+            pytest.param(
+                OrderedDict, collections.OrderedDict, "OrderedDict", id="ordereddict"
+            ),
+        ],
+    )
+    class TestEach:
+        def test_valid(self, annotation, factory, type_name):
+            check_type(factory({"aa": 1}), annotation[str, int])
+
+        def test_bad_key_type(self, annotation, factory, type_name):
+            pytest.raises(
+                TypeCheckError, check_type, factory({1: 2}), annotation[str, int]
+            ).match("is not an instance of str")
+
+        def test_bad_value_type(self, annotation, factory, type_name):
+            pytest.raises(
+                TypeCheckError, check_type, factory({"aa": "bb"}), annotation[str, int]
+            ).match("is not an instance of int")
+
+        def test_plain_dict_is_rejected(self, annotation, factory, type_name):
+            pytest.raises(
+                TypeCheckError, check_type, {"aa": 1}, annotation[str, int]
+            ).match(f"dict is not a {type_name}")
+
+        def test_full_check_fail(self, annotation, factory, type_name):
+            pytest.raises(
+                TypeCheckError,
+                check_type,
+                factory({"aa": 1, "bb": "x"}),
+                annotation[str, int],
+                collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS,
+            ).match("is not an instance of int")
 
 
 class TestTypedDict:


### PR DESCRIPTION
None of the three have checkers registered, so their key and value types get dropped. A plain dict also passes for any of them, since nothing tests the concrete type:

    check_type({"a": 1}, OrderedDict[str, int])                    # passes
    check_type(defaultdict(int, {1: "a"}), DefaultDict[str, int])  # passes

check_mapping already covers the contents and special-cases dict by origin, so the concrete types are looked up the same way rather than through three near-identical checkers.

Counter is left alone here - it takes a single argument and needs different handling