### PR TITLE
Check the contents of Counter annotations

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,8 @@ This library adheres to
 
 **UNRELEASED**
 
+- Added type checking of the contents of ``Counter`` annotations; the key type was
+  previously ignored, and a plain ``dict`` was accepted as a ``Counter``
 - Fixed ``ReadOnly`` (:pep:`705`) qualifiers on ``TypedDict`` items being left
   unwrapped, which caused the item's value type to skip type checking entirely
   (`#571 <https://github.com/agronholm/typeguard/pull/571>`_; PR by @jaideeppyne)

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -21,6 +21,7 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
+    Counter,
     Dict,
     ForwardRef,
     List,
@@ -215,6 +216,26 @@ def check_callable(
                     f"{len(argument_types)} but {num_positional_args} argument(s) "
                     f"declared"
                 )
+
+
+def check_counter(
+    value: Any,
+    origin_type: Any,
+    args: tuple[Any, ...],
+    memo: TypeCheckMemo,
+) -> None:
+    if not isinstance(value, collections.Counter):
+        raise TypeCheckError("is not a Counter")
+
+    # Counter takes a single argument for the key; the values are always ints
+    if args and args != (Any,):
+        samples = memo.config.collection_check_strategy.iterate_samples(value)
+        for key in samples:
+            try:
+                check_type_internal(key, args[0], memo)
+            except TypeCheckError as exc:
+                exc.append_path_element(f"key {key!r}")
+                raise
 
 
 def check_mapping(
@@ -1054,6 +1075,8 @@ origin_type_checkers: dict[
     Mapping: check_mapping,
     MutableMapping: check_mapping,
     None: check_none,
+    collections.Counter: check_counter,
+    Counter: check_counter,
     collections.abc.Mapping: check_mapping,
     collections.abc.MutableMapping: check_mapping,
     Sequence: check_sequence,

--- a/src/typeguard/_config.py
+++ b/src/typeguard/_config.py
@@ -34,6 +34,7 @@ class CollectionCheckStrategy(Enum):
     This has an effect on the following built-in checkers:
 
     * ``AbstractSet``
+    * ``Counter``
     * ``Dict``
     * ``List``
     * ``Mapping``

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -18,6 +18,7 @@ from typing import (
     Collection,
     Concatenate,
     ContextManager,
+    Counter,
     Dict,
     ForwardRef,
     FrozenSet,
@@ -446,6 +447,33 @@ class TestDict:
                     yield key, self[key]
 
         check_type(CustomDict(a=1), Dict[str, int])
+
+
+class TestCounter:
+    def test_bad_type(self):
+        pytest.raises(TypeCheckError, check_type, {"aa": 1}, Counter[str]).match(
+            "dict is not a Counter"
+        )
+
+    def test_valid(self):
+        check_type(collections.Counter("aabb"), Counter[str])
+
+    def test_empty(self):
+        check_type(collections.Counter(), Counter[str])
+
+    def test_bad_key_type(self):
+        pytest.raises(
+            TypeCheckError, check_type, collections.Counter({1: 2}), Counter[str]
+        ).match("is not an instance of str")
+
+    def test_full_check_fail(self):
+        pytest.raises(
+            TypeCheckError,
+            check_type,
+            collections.Counter({"aa": 1, 2: 3}),
+            Counter[str],
+            collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS,
+        ).match("is not an instance of str")
 
 
 class TestTypedDict:


### PR DESCRIPTION
Counter has no checker registered:

    check_type(Counter({1: 2}), Counter[str])  # passes
    check_type({"a": 1}, Counter[str])         # passes - a plain dict

It takes a single argument for the key rather than the two check_mapping unpacks, since the values are always counts, so it gets its own checker