### PR TITLE
Check Pattern and Match annotations

### DIFF
--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,9 @@ This library adheres to
 
 **UNRELEASED**
 
+- Added type checking of ``Pattern`` and ``Match`` annotations; the ``str``/``bytes``
+  argument was previously ignored, so ``Pattern[str]`` accepted a pattern compiled from
+  bytes, and neither was checked against the wrong kind of object
 - Fixed ``ReadOnly`` (:pep:`705`) qualifiers on ``TypedDict`` items being left
   unwrapped, which caused the item's value type to skip type checking entirely
   (`#571 <https://github.com/agronholm/typeguard/pull/571>`_; PR by @jaideeppyne)

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import collections.abc
 import inspect
+import re
 import sys
 import types
 import typing
@@ -24,7 +25,9 @@ from typing import (
     Dict,
     ForwardRef,
     List,
+    Match,
     NewType,
+    Pattern,
     Set,
     TextIO,
     Tuple,
@@ -215,6 +218,31 @@ def check_callable(
                     f"{len(argument_types)} but {num_positional_args} argument(s) "
                     f"declared"
                 )
+
+
+def check_pattern_or_match(
+    value: Any,
+    origin_type: Any,
+    args: tuple[Any, ...],
+    memo: TypeCheckMemo,
+) -> None:
+    if origin_type in (Pattern, re.Pattern):
+        if not isinstance(value, re.Pattern):
+            raise TypeCheckError("is not a compiled pattern")
+
+        pattern = value.pattern
+    else:
+        if not isinstance(value, re.Match):
+            raise TypeCheckError("is not a match object")
+
+        pattern = value.re.pattern
+
+    if args and args != (Any,):
+        # The argument is the string flavour the pattern was compiled from
+        if args[0] is str and not isinstance(pattern, str):
+            raise TypeCheckError("is not a string pattern")
+        if args[0] is bytes and not isinstance(pattern, bytes):
+            raise TypeCheckError("is not a bytes pattern")
 
 
 def check_mapping(
@@ -1053,7 +1081,11 @@ origin_type_checkers: dict[
     typing.Literal: check_literal,
     Mapping: check_mapping,
     MutableMapping: check_mapping,
+    re.Match: check_pattern_or_match,
+    Match: check_pattern_or_match,
     None: check_none,
+    re.Pattern: check_pattern_or_match,
+    Pattern: check_pattern_or_match,
     collections.abc.Mapping: check_mapping,
     collections.abc.MutableMapping: check_mapping,
     Sequence: check_sequence,

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -1,4 +1,5 @@
 import collections.abc
+import re
 import sys
 import types
 from contextlib import nullcontext
@@ -26,8 +27,10 @@ from typing import (
     List,
     Literal,
     Mapping,
+    Match,
     MutableMapping,
     ParamSpec,
+    Pattern,
     Protocol,
     Sequence,
     Set,
@@ -446,6 +449,55 @@ class TestDict:
                     yield key, self[key]
 
         check_type(CustomDict(a=1), Dict[str, int])
+
+
+class TestPattern:
+    def test_bad_type(self):
+        pytest.raises(TypeCheckError, check_type, "x", Pattern[str]).match(
+            "str is not a compiled pattern"
+        )
+
+    def test_valid_str(self):
+        check_type(re.compile("x"), Pattern[str])
+
+    def test_valid_bytes(self):
+        check_type(re.compile(b"x"), Pattern[bytes])
+
+    def test_unparametrized(self):
+        check_type(re.compile("x"), Pattern)
+
+    def test_bytes_pattern_against_str(self):
+        pytest.raises(TypeCheckError, check_type, re.compile(b"x"), Pattern[str]).match(
+            "re.Pattern is not a string pattern"
+        )
+
+    def test_str_pattern_against_bytes(self):
+        pytest.raises(
+            TypeCheckError, check_type, re.compile("x"), Pattern[bytes]
+        ).match("re.Pattern is not a bytes pattern")
+
+
+class TestMatch:
+    def test_bad_type(self):
+        pytest.raises(TypeCheckError, check_type, "x", Match[str]).match(
+            "str is not a match object"
+        )
+
+    def test_pattern_is_not_a_match(self):
+        pytest.raises(TypeCheckError, check_type, re.compile("x"), Match[str]).match(
+            "re.Pattern is not a match object"
+        )
+
+    def test_valid_str(self):
+        check_type(re.match("x", "x"), Match[str])
+
+    def test_valid_bytes(self):
+        check_type(re.match(b"x", b"x"), Match[bytes])
+
+    def test_bytes_match_against_str(self):
+        pytest.raises(
+            TypeCheckError, check_type, re.match(b"x", b"x"), Match[str]
+        ).match("re.Match is not a string pattern")
 
 
 class TestTypedDict:


### PR DESCRIPTION
Neither has a checker registered, so both fall through to a plain isinstance against the bare type:

    check_type(re.compile(b"x"), Pattern[str])   # passes
    check_type(re.compile("x"), Pattern[bytes])  # passes
    check_type(re.compile("x"), Match[str])      # passes - a pattern, not a match

The argument says which flavour the pattern was compiled from, so it is checked against the pattern itself rather than against anything matched