### PR TITLE
Fix nested Never and NoReturn checks

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -187,7 +187,8 @@ The following types from the standard library have specialized support:
      - Field values are typechecked
    * - | :class:`typing.Never`
        | :class:`typing.NoReturn`
-     - Supported in argument and return type annotations
+     - No value is compatible with either annotation, including when nested inside
+       another supported annotation
    * - :class:`typing.Protocol`
      - Run-time protocols are checked with :func:`isinstance`, others are ignored
    * - :class:`typing.Self`

--- a/docs/versionhistory.rst
+++ b/docs/versionhistory.rst
@@ -6,6 +6,8 @@ This library adheres to
 
 **UNRELEASED**
 
+- Fixed ``Never`` and ``NoReturn`` being ignored when nested inside another type
+  annotation (`#580 <https://github.com/agronholm/typeguard/issues/580>`_; PR by @PNHD)
 - Fixed ``ReadOnly`` (:pep:`705`) qualifiers on ``TypedDict`` items being left
   unwrapped, which caused the item's value type to skip type checking entirely
   (`#571 <https://github.com/agronholm/typeguard/pull/571>`_; PR by @jaideeppyne)

--- a/src/typeguard/_checkers.py
+++ b/src/typeguard/_checkers.py
@@ -953,6 +953,15 @@ def check_paramspec(
     pass  # No-op for now
 
 
+def check_never(
+    value: Any,
+    origin_type: Any,
+    args: tuple[Any, ...],
+    memo: TypeCheckMemo,
+) -> None:
+    raise TypeCheckError(f"is not compatible with {get_type_name(origin_type)}")
+
+
 def check_type_internal(
     value: Any,
     annotation: Any,
@@ -1054,6 +1063,7 @@ origin_type_checkers: dict[
     Mapping: check_mapping,
     MutableMapping: check_mapping,
     None: check_none,
+    typing.NoReturn: check_never,
     collections.abc.Mapping: check_mapping,
     collections.abc.MutableMapping: check_mapping,
     Sequence: check_sequence,
@@ -1074,13 +1084,18 @@ origin_type_checkers: dict[
     # It's best to err on the safe side and just always specify these.
     typing_extensions.Literal: check_literal,
     typing_extensions.LiteralString: check_literal_string,
+    typing_extensions.Never: check_never,
     typing_extensions.Self: check_self,
     typing_extensions.TypeGuard: check_typeguard,
 }
 
 if sys.version_info >= (3, 11):
     origin_type_checkers.update(
-        {typing.LiteralString: check_literal_string, typing.Self: check_self}
+        {
+            typing.LiteralString: check_literal_string,
+            typing.Never: check_never,
+            typing.Self: check_self,
+        }
     )
 
 if sys.version_info >= (3, 12):

--- a/src/typeguard/_functions.py
+++ b/src/typeguard/_functions.py
@@ -169,6 +169,7 @@ def check_argument_types_internal(
             )
             if memo.config.typecheck_fail_callback:
                 memo.config.typecheck_fail_callback(exc, memo)
+                continue
             else:
                 raise exc
 
@@ -219,6 +220,7 @@ def check_return_type_internal(
         exc = TypeCheckError(f"{func_name}() was declared never to return but it did")
         if memo.config.typecheck_fail_callback:
             memo.config.typecheck_fail_callback(exc, memo)
+            return retval
         else:
             raise exc
 
@@ -257,6 +259,7 @@ def check_send_type(
         )
         if memo.config.typecheck_fail_callback:
             memo.config.typecheck_fail_callback(exc, memo)
+            return sendval
         else:
             raise exc
 
@@ -286,6 +289,7 @@ def check_yield_type(
         exc = TypeCheckError(f"{func_name}() was declared never to yield but it did")
         if memo.config.typecheck_fail_callback:
             memo.config.typecheck_fail_callback(exc, memo)
+            return yieldval
         else:
             raise exc
 

--- a/tests/test_never_nested.py
+++ b/tests/test_never_nested.py
@@ -1,0 +1,32 @@
+import sys
+from collections.abc import Sequence
+from typing import NoReturn, Union
+
+import pytest
+
+from typeguard import TypeCheckError, check_type
+
+if sys.version_info >= (3, 11):
+    from typing import Never
+else:
+    from typing_extensions import Never
+
+
+@pytest.mark.parametrize(
+    ("annotation", "value"),
+    [
+        pytest.param(list[Never], [1], id="list"),
+        pytest.param(dict[str, Never], {"key": 1}, id="dict"),
+        pytest.param(Union[int, Never], "value", id="union"),
+        pytest.param(Union[Never, None], 1, id="optional"),
+        pytest.param(tuple[Never, ...], (1, 2), id="tuple"),
+        pytest.param(Sequence[NoReturn], [1], id="sequence-noreturn"),
+    ],
+)
+def test_nested_never_rejects_values(annotation, value):
+    with pytest.raises(TypeCheckError):
+        check_type(value, annotation)
+
+
+def test_union_with_never_accepts_other_member():
+    assert check_type(1, Union[int, Never]) == 1


### PR DESCRIPTION
## Changes

Fixes #580.

Register `Never` and `NoReturn` with the internal checker so values are rejected when these bottom types appear inside supported container or union annotations. Keep the existing specialized behavior for bare argument, return, send, and yield annotations, including fail-callback handling.

Update the supported-annotations documentation and unreleased changelog entry.

## Checklist

- [x] You've added tests (in `tests/`) added which would fail without your patch
- [x] You've updated the documentation (in `docs/`, in case of behavior changes or new features)
- [x] You've added a new changelog entry (in `docs/versionhistory.rst`).

Validation: the regression test reproduced six missed nested checks before the fix; the focused tests, full suite, pre-commit hooks, and the project matrix on CPython 3.10 through 3.15 plus PyPy 3.11 all pass after the fix.